### PR TITLE
Fix legacy QUBO.jl repository links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+test:
+	@if git grep -nE '(github\.com|raw\.githubusercontent\.com)/(psrenergy|psrnergy)/QUBO\.jl' -- '*.md' '*.ipynb' '*.yml' '*.yaml'; then \
+		echo "Found legacy QUBO.jl repository links"; \
+		exit 1; \
+	fi
+
 sysimage:
 	julia -e 'using InteractiveUtils; versioninfo()'
 	julia --project=./notebooks -e 'import Pkg; Pkg.instantiate()'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # QUBO-notebooks
 
 <div align="center">
-  <a href="https://github.com/psrnergy/QUBO.jl">
-    <img width="400px" src="https://raw.githubusercontent.com/psrenergy/QUBO.jl/master/docs/src/assets/logo.svg" alt="QUBO.jl" />
+  <a href="https://github.com/JuliaQUBO/QUBO.jl">
+    <img width="400px" src="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg" alt="QUBO.jl" />
   </a>
   <br>
-  <span>Quantum Integer Programming Notebooks using <a href="https://jump.dev">JuMP</a> and <a href="https://github.com/psrnergy/QUBO.jl">QUBO.jl</a>.</span>
+  <span>Quantum Integer Programming Notebooks using <a href="https://jump.dev">JuMP</a> and <a href="https://github.com/JuliaQUBO/QUBO.jl">QUBO.jl</a>.</span>
   <br>
   <br>
   <a href="https://bernalde.github.io">David E. Bernal Neira</a>

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -957,7 +957,7 @@
         "\n",
         "This notebook will explain the basics of the QUBO modeling.\n",
         "In order to implement the different QUBO formulations we will use **[JuMP](https://jump.dev)**, and then solve them using **[neal](https://github.com/dwavesystems/dwave-neal)**'s implementation of simulated annealing.\n",
-        "We will also leverage the use of **[QUBO.jl](https://github.com/psrenergy/QUBO.jl)** to translate constraint satisfaction problems to QUBOs.\n",
+        "We will also leverage the use of **[QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl)** to translate constraint satisfaction problems to QUBOs.\n",
         "Finally, for we will use **[Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl)** for network models/graphs."
       ]
     },

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -93,7 +93,7 @@
    "source": [
     "## Ising model\n",
     "This notebook will explain the basics of the Ising model.\n",
-    "In order to implement the different Ising Models we will use **[JuMP](https://jump.dev)** and **[QUBO.jl](https://github.com/psrenergy/QUBO.jl)**, for defining the Ising model and solving it with simulated annealing."
+    "In order to implement the different Ising Models we will use **[JuMP](https://jump.dev)** and **[QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl)**, for defining the Ising model and solving it with simulated annealing."
    ]
   },
   {

--- a/templates/qubo.ipynb
+++ b/templates/qubo.ipynb
@@ -11,7 +11,7 @@
         "# QUBO.jl Notebook Template\n",
         "\n",
         "<div align=\"center\">\n",
-        "    <img src=\"https://raw.githubusercontent.com/psrenergy/QUBO.jl/master/docs/src/assets/logo.svg\" width=\"400px\" alt=\"QUBO.jl\">\n",
+        "    <img src=\"https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg\" width=\"400px\" alt=\"QUBO.jl\">\n",
         "    <br>\n",
         "    <a href=\"https://colab.research.google.com/github/pedromxavier/QUBO-notebooks/blob/main/julia-template.ipynb\" target=\"_parent\">\n",
         "        <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",


### PR DESCRIPTION
## Summary

- Updated legacy QUBO.jl repository links from `psrenergy`/`psrnergy` to `JuliaQUBO`.
- Updated raw QUBO.jl logo URLs from the old `master` branch path to the canonical `main` branch path.
- Added a `make test` regression check that fails if tracked Markdown, notebook, or workflow files contain legacy QUBO.jl owner URLs.

## Tests run

- `make test` - passed
- `jq empty templates/qubo.ipynb notebooks_jl/2-QUBO.ipynb notebooks_jl/5-Benchmarking.ipynb` - passed
- `git diff --check` - passed
- `rg -n "psrenergy|psrnergy" README.md templates notebooks_jl notebooks_py .github` - no matches

## Notes

- `make sysimage` was discovered as the deployment/sysimage build command, but was not run locally because this PR only changes documentation/notebook links and the sysimage build is a heavyweight release artifact rather than a targeted validation for these changes.

Closes #13
