### PR TITLE
Clean QUBO.jl repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # QUBO-notebooks
 
 <div align="center">
-  <a href="https://github.com/psrnergy/QUBO.jl">
-    <img width="400px" src="https://raw.githubusercontent.com/psrenergy/QUBO.jl/master/docs/src/assets/logo.svg" alt="QUBO.jl" />
+  <a href="https://github.com/JuliaQUBO/QUBO.jl">
+    <img width="400px" src="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg" alt="QUBO.jl" />
   </a>
   <br>
-  <span>Quantum Integer Programming Notebooks using <a href="https://jump.dev">JuMP</a> and <a href="https://github.com/psrnergy/QUBO.jl">QUBO.jl</a>.</span>
+  <span>Quantum Integer Programming Notebooks using <a href="https://jump.dev">JuMP</a> and <a href="https://github.com/JuliaQUBO/QUBO.jl">QUBO.jl</a>.</span>
   <br>
   <br>
   <a href="https://bernalde.github.io">David E. Bernal Neira</a>

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -957,7 +957,7 @@
         "\n",
         "This notebook will explain the basics of the QUBO modeling.\n",
         "In order to implement the different QUBO formulations we will use **[JuMP](https://jump.dev)**, and then solve them using **[neal](https://github.com/dwavesystems/dwave-neal)**'s implementation of simulated annealing.\n",
-        "We will also leverage the use of **[QUBO.jl](https://github.com/psrenergy/QUBO.jl)** to translate constraint satisfaction problems to QUBOs.\n",
+        "We will also leverage the use of **[QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl)** to translate constraint satisfaction problems to QUBOs.\n",
         "Finally, for we will use **[Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl)** for network models/graphs."
       ]
     },

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -93,7 +93,7 @@
    "source": [
     "## Ising model\n",
     "This notebook will explain the basics of the Ising model.\n",
-    "In order to implement the different Ising Models we will use **[JuMP](https://jump.dev)** and **[QUBO.jl](https://github.com/psrenergy/QUBO.jl)**, for defining the Ising model and solving it with simulated annealing."
+    "In order to implement the different Ising Models we will use **[JuMP](https://jump.dev)** and **[QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl)**, for defining the Ising model and solving it with simulated annealing."
    ]
   },
   {

--- a/templates/qubo.ipynb
+++ b/templates/qubo.ipynb
@@ -11,7 +11,7 @@
         "# QUBO.jl Notebook Template\n",
         "\n",
         "<div align=\"center\">\n",
-        "    <img src=\"https://raw.githubusercontent.com/psrenergy/QUBO.jl/master/docs/src/assets/logo.svg\" width=\"400px\" alt=\"QUBO.jl\">\n",
+        "    <img src=\"https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg\" width=\"400px\" alt=\"QUBO.jl\">\n",
         "    <br>\n",
         "    <a href=\"https://colab.research.google.com/github/pedromxavier/QUBO-notebooks/blob/main/julia-template.ipynb\" target=\"_parent\">\n",
         "        <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,34 @@
+using Test
+
+repo_root = dirname(@__DIR__)
+
+files_with_qubo_links = [
+    "README.md",
+    joinpath("templates", "qubo.ipynb"),
+    joinpath("notebooks_jl", "2-QUBO.ipynb"),
+    joinpath("notebooks_jl", "5-Benchmarking.ipynb"),
+]
+legacy_owners = ["psr" * "energy", "psr" * "nergy"]
+
+@testset "QUBO.jl repository links" begin
+    for file in files_with_qubo_links
+        contents = read(joinpath(repo_root, file), String)
+
+        for owner in legacy_owners
+            @test !occursin("$owner/QUBO.jl", contents)
+        end
+    end
+
+    readme = read(joinpath(repo_root, "README.md"), String)
+    template = read(joinpath(repo_root, "templates", "qubo.ipynb"), String)
+
+    @test occursin("https://github.com/JuliaQUBO/QUBO.jl", readme)
+    @test occursin(
+        "https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg",
+        readme,
+    )
+    @test occursin(
+        "https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/main/docs/src/assets/logo.svg",
+        template,
+    )
+end


### PR DESCRIPTION
## Summary

- Updated QUBO.jl repository links from the legacy PSR owners to `JuliaQUBO/QUBO.jl`.
- Updated raw logo asset URLs from the old `master` branch path to the canonical `main` branch path.
- Added a focused regression test that checks the affected docs/notebooks for legacy QUBO.jl owner links.

## Tests run

- `julia --startup-file=no test/runtests.jl` - passed, 11 tests.
- `jq empty templates/qubo.ipynb notebooks_jl/2-QUBO.ipynb notebooks_jl/5-Benchmarking.ipynb` - passed.
- `git diff --check` - passed.
- `rg -n "psrenergy|psrnergy" .` - passed with no matches.

## Notes

- Did not run `make sysimage`; it is the repository's documented workflow command, but it builds a Julia sysimage and release artifact and is not practical or relevant for this docs-link-only change.

Closes #13
