### PR TITLE
Fix Julia Colab setup for QUBO and GAMA notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ long benchmark runs.
 | Topic | Julia notebook | Python notebook | Local verification status |
 | --- | --- | --- | --- |
 | Linear and Integer Programming | [notebooks_jl/1-MathProg.ipynb](notebooks_jl/1-MathProg.ipynb) | [notebooks_py/1-MathProg_python.ipynb](notebooks_py/1-MathProg_python.ipynb) | Requires local LP/NLP/MINLP solver binaries. |
-| QUBO and Ising | [notebooks_jl/2-QUBO.ipynb](notebooks_jl/2-QUBO.ipynb) | [notebooks_py/2-QUBO_python.ipynb](notebooks_py/2-QUBO_python.ipynb) | Python notebook is portable and covered by `make verify-qubo-python`. |
-| Graver Augmented Multiseed Algorithm | [notebooks_jl/3-GAMA.ipynb](notebooks_jl/3-GAMA.ipynb) | [notebooks_py/3-GAMA_python.ipynb](notebooks_py/3-GAMA_python.ipynb) | Python notebook is portable and covered by `make verify-gama-python`. |
+| QUBO and Ising | [notebooks_jl/2-QUBO.ipynb](notebooks_jl/2-QUBO.ipynb) | [notebooks_py/2-QUBO_python.ipynb](notebooks_py/2-QUBO_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-qubo-python`. |
+| Graver Augmented Multiseed Algorithm | [notebooks_jl/3-GAMA.ipynb](notebooks_jl/3-GAMA.ipynb) | [notebooks_py/3-GAMA_python.ipynb](notebooks_py/3-GAMA_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-gama-python`. |
 | D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Requires D-Wave solver access for quantum annealer cells. |
 | Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Long-running benchmark notebook with generated artifacts. |
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
@@ -72,6 +72,8 @@ external solver credentials or longer-running jobs; those targets are not part
 of the default portable subset. The QCi notebook does not yet have a locked
 local make target because `eqc-models==0.19.0` requires `networkx<3`, which
 conflicts with the D-Wave Ocean stack.
+The Julia QUBO and GAMA notebooks use `scripts/install-colab-julia.sh` in Colab
+to install Julia and the latest precompiled QUBONotebooks sysimage.
 
 ```bash
 make verify-notebooks NOTEBOOKS="notebooks_py/2-QUBO_python.ipynb" UV_GROUP_FLAGS="--group docs --group qubo"

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -37,6 +37,34 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "colab-install-instructions"
+      },
+      "source": [
+        "## Colab Instructions\n",
+        "\n",
+        "If not in a Colab notebook, continue to the next section.\n",
+        "\n",
+        "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
+        "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
+        "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "colab-install-julia"
+      },
+      "outputs": [],
+      "source": [
+        "%%shell\n",
+        "\n",
+        "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "62lsY_yx3n5f"
       },
       "source": [

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -41,6 +41,31 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "## Colab Instructions\n",
+        "\n",
+        "If not in a Colab notebook, continue to the next section.\n",
+        "\n",
+        "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
+        "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
+        "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%shell\n",
+        "\n",
+        "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "### Activate Environment"
       ]
     },

--- a/scripts/create_sysimage.jl
+++ b/scripts/create_sysimage.jl
@@ -10,11 +10,13 @@ const PACKAGES = [
     # Misc
     "Graphs",
     "Karnak",
+    "Luxor",
     "SpecialFunctions",
 
     # GAMA
     "BinaryWrappers",
     "lib4ti2_jll",
+    "NPZ",
 
     # JuMP
     "AmplNLWriter",
@@ -27,17 +29,16 @@ const PACKAGES = [
     "JuMP",
 
     # QUBO
+    "DWave",
+    "PythonCall",
     "QUBO",
-    # "DWave",     # These use PythonCall!
-    # "DWaveNeal",
 
     # Visualization
-    # "Plots",
     "Measures",
-    # "PythonCall",
+    "Plots",
     # "PythonPlot",
     "StatsBase",
-    # "StatsPlots",
+    "StatsPlots",
 ]
 
 PackageCompiler.create_sysimage(

--- a/scripts/install-colab-julia.sh
+++ b/scripts/install-colab-julia.sh
@@ -67,7 +67,7 @@ function install-colab-julia {
 }
 
 if [[ $# -eq 0 ]]; then
-    install-colab-julia "1.10.2" 2
+    install-colab-julia "1.10.11" 2
 elif [[ $# -eq 1 ]]; then
     install-colab-julia "$1" 2
 else

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -11,9 +11,19 @@ from unittest.mock import Mock, patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "scripts" / "verify_notebooks.py"
+QUBO_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "2-QUBO.ipynb"
+GAMA_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "3-GAMA.ipynb"
 GAMA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "3-GAMA_python.ipynb"
 DWAVE_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb"
 DWAVE_PYTHON_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "4-DWAVE_python.ipynb"
+JULIA_COLAB_NOTEBOOK_PATHS = (
+    QUBO_JULIA_NOTEBOOK_PATH,
+    GAMA_JULIA_NOTEBOOK_PATH,
+)
+COLAB_JULIA_INSTALLER = (
+    'bash <(curl -s "https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/'
+    'scripts/install-colab-julia.sh")'
+)
 NOTEBOOK_DIRS = (
     REPO_ROOT / "notebooks_jl",
     REPO_ROOT / "notebooks_py",
@@ -43,6 +53,11 @@ def notebook_cell_source(path: Path, marker: str) -> str:
             return source
 
     raise AssertionError(f"Could not find notebook cell containing {marker!r}")
+
+
+def notebook_cell_sources(path: Path) -> list[str]:
+    notebook = json.loads(path.read_text())
+    return ["".join(cell.get("source", [])) for cell in notebook["cells"]]
 
 
 def notebook_paths() -> list[Path]:
@@ -229,6 +244,58 @@ class RepositoryCommandTests(unittest.TestCase):
         self.assertIn('"notebooks_jl"', prepare_release)
         self.assertNotIn('"notebooks"', create_sysimage)
         self.assertNotIn('"notebooks"', prepare_release)
+
+    def test_colab_installer_default_matches_sysimage_julia_version(self) -> None:
+        install_script = (REPO_ROOT / "scripts" / "install-colab-julia.sh").read_text()
+        deploy_workflow = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+        notebook_manifest = (REPO_ROOT / "notebooks_jl" / "Manifest.toml").read_text()
+        expected_version = "1.10.11"
+
+        self.assertIn(f'install-colab-julia "{expected_version}" 2', install_script)
+        self.assertIn(f"julia-version: '{expected_version}'", deploy_workflow)
+        self.assertIn(f'julia_version = "{expected_version}"', notebook_manifest)
+
+    def test_sysimage_includes_julia_qubo_and_gama_runtime_packages(self) -> None:
+        create_sysimage = (REPO_ROOT / "scripts" / "create_sysimage.jl").read_text()
+        package_lines = {line.strip() for line in create_sysimage.splitlines()}
+
+        expected_packages = {
+            '"BinaryWrappers",',
+            '"DWave",',
+            '"Graphs",',
+            '"JuMP",',
+            '"Karnak",',
+            '"lib4ti2_jll",',
+            '"Luxor",',
+            '"Measures",',
+            '"NPZ",',
+            '"Plots",',
+            '"PythonCall",',
+            '"QUBO",',
+            '"StatsBase",',
+            '"StatsPlots",',
+        }
+
+        self.assertTrue(
+            expected_packages.issubset(package_lines),
+            expected_packages - package_lines,
+        )
+
+
+class JuliaColabSetupTests(unittest.TestCase):
+    def test_julia_qubo_and_gama_notebooks_install_colab_julia_before_activation(self) -> None:
+        for path in JULIA_COLAB_NOTEBOOK_PATHS:
+            with self.subTest(path=path.relative_to(REPO_ROOT).as_posix()):
+                cells = notebook_cell_sources(path)
+                install_index = next(
+                    i for i, source in enumerate(cells) if COLAB_JULIA_INSTALLER in source
+                )
+                activate_index = next(
+                    i for i, source in enumerate(cells) if "Pkg.activate(@__DIR__)" in source
+                )
+
+                self.assertLess(install_index, activate_index)
+                self.assertIn("precompiled QUBONotebooks sysimage", cells[install_index - 1])
 
 
 class GamaNotebookTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add Colab setup cells to the Julia QUBO and GAMA notebooks before environment activation
- align the Colab installer default Julia version with the Julia 1.10.11 sysimage build and manifests
- include the Julia QUBO/GAMA runtime packages in the sysimage package list, including DWave, PythonCall, Plots, StatsPlots, Luxor, and NPZ
- add regression tests for the Colab setup cells, installer/sysimage Julia version alignment, and sysimage package coverage

Notebook outputs were intentionally not re-executed; this PR changes setup cells and release sysimage configuration rather than notebook computational outputs.

Refs #10. The issue should be closed after this change is merged and a refreshed latest QUBONotebooks sysimage release has been published.

## Post-Merge Release Step

After merging, run the `Create & Deploy Sysimage` workflow from the merged commit to publish a new latest `sysimage.tar.gz`. The Colab installer downloads `releases/latest/download/sysimage.tar.gz`, so Colab users will not receive the expanded DWave/PythonCall/Plots/StatsPlots sysimage contents until that release is available.

## Validation

- `make test`
- `UV_CACHE_DIR="$PWD/.uv-cache" make test-python PYTHON="uv run --locked --group docs python"`
- `make test-julia`
- `JULIA_DEPOT_PATH="$PWD/.julia-depot:$HOME/.julia" JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=./notebooks_jl -e 'import Pkg; Pkg.instantiate(); using QUBO, DWave, PythonCall, Plots, StatsPlots, NPZ, BinaryWrappers, lib4ti2_jll, Luxor; println("imports ok")'`
- `git diff --check`

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-10-julia-colab`
- Branch point: `origin/main` at `8d04fb17f50946a8169048dd3cd92473eee96a88`
- Stacked status: not stacked; no prerequisite PRs
