### PR TITLE
Fix Colab sysimage depot path

### DIFF
--- a/.github/workflows/NOTES.md
+++ b/.github/workflows/NOTES.md
@@ -5,7 +5,11 @@
 ```shell
 wget "https://github.com/JuliaQUBO/QUBONotebooks/releases/${TAG}/download/sysimage.tar.gz" -O sysimage.tar.gz
 
-tar -xzf sysimage.tar.gz # sysimage.so, Project.toml, Manifest.toml
+mkdir -p /content/.julia-depot
+tar -xzf sysimage.tar.gz -C /content # sysimage.so, Project.toml, Manifest.toml
+export JULIA_DEPOT_PATH="/content/.julia-depot:${JULIA_DEPOT_PATH:-$HOME/.julia}"
+julia --project=/content -e 'import Pkg; Pkg.instantiate()'
+julia --project=/content --sysimage=/content/sysimage.so
 ```
 
 ### SHA256

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,12 +20,18 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JULIA_DEPOT_PATH: /content/.julia-depot:/home/runner/.julia
+      JULIA_PKG_PRECOMPILE_AUTO: 0
     steps:
     - uses: actions/checkout@v7
     - uses: julia-actions/setup-julia@v3
       with:
         version: ${{ matrix.julia-version }}
         arch: ${{ matrix.arch }}
+    - name: Prepare Colab-compatible Julia depot
+      run: |
+        sudo mkdir -p /content/.julia-depot
+        sudo chown -R "$USER":"$USER" /content
     - name: Create Sysimage
       run: make sysimage
 

--- a/scripts/install-colab-julia.sh
+++ b/scripts/install-colab-julia.sh
@@ -5,6 +5,7 @@ function install-colab-julia {
 
     JULIA_VERSION="$1" # any version ≥ 0.7.0
     JULIA_NUM_THREADS="$2"
+    COLAB_JULIA_DEPOT="/content/.julia-depot"
 
     if [ -z `which julia` ]; then
         # Install Julia
@@ -31,6 +32,10 @@ function install-colab-julia {
         # Remove Tarball
         rm /tmp/sysimage.tar.gz
 
+        # Match the depot path used to build the sysimage. PythonCall-backed
+        # packages load runtime helper files relative to their compiled paths.
+        export JULIA_DEPOT_PATH="$COLAB_JULIA_DEPOT:${JULIA_DEPOT_PATH:-$HOME/.julia}"
+
         # Install Packages & Create Kernel
         julia --project=/content -e '
             ENV["JULIA_PKG_PRECOMPILE_AUTO"] = 0
@@ -51,7 +56,11 @@ function install-colab-julia {
             IJulia.installkernel(
                 "QUBO.jl Julia",
                 "--project=/content", "--sysimage=/content/sysimage.so";
-                env = Dict("JULIA_NUM_THREADS"=>"'"$JULIA_NUM_THREADS"'")
+                env = Dict(
+                    "JULIA_NUM_THREADS"=>"'"$JULIA_NUM_THREADS"'",
+                    "JULIA_DEPOT_PATH"=>ENV["JULIA_DEPOT_PATH"],
+                    "JULIA_PKG_PRECOMPILE_AUTO"=>"0",
+                )
             );
         '
 

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -255,6 +255,22 @@ class RepositoryCommandTests(unittest.TestCase):
         self.assertIn(f"julia-version: '{expected_version}'", deploy_workflow)
         self.assertIn(f'julia_version = "{expected_version}"', notebook_manifest)
 
+    def test_sysimage_build_and_colab_kernel_use_matching_depot_path(self) -> None:
+        install_script = (REPO_ROOT / "scripts" / "install-colab-julia.sh").read_text()
+        deploy_workflow = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+        release_notes = (REPO_ROOT / ".github" / "workflows" / "NOTES.md").read_text()
+
+        self.assertIn(
+            "JULIA_DEPOT_PATH: /content/.julia-depot:/home/runner/.julia",
+            deploy_workflow,
+        )
+        self.assertIn("sudo mkdir -p /content/.julia-depot", deploy_workflow)
+        self.assertIn('COLAB_JULIA_DEPOT="/content/.julia-depot"', install_script)
+        self.assertIn('export JULIA_DEPOT_PATH="$COLAB_JULIA_DEPOT:', install_script)
+        self.assertIn('"JULIA_DEPOT_PATH"=>ENV["JULIA_DEPOT_PATH"]', install_script)
+        self.assertIn("tar -xzf sysimage.tar.gz -C /content", release_notes)
+        self.assertIn('export JULIA_DEPOT_PATH="/content/.julia-depot:', release_notes)
+
     def test_sysimage_includes_julia_qubo_and_gama_runtime_packages(self) -> None:
         create_sysimage = (REPO_ROOT / "scripts" / "create_sysimage.jl").read_text()
         package_lines = {line.strip() for line in create_sysimage.splitlines()}


### PR DESCRIPTION
## Summary
- build the release sysimage with the same /content/.julia-depot path used by Colab
- export that depot path in the Colab installer and persist it into the IJulia kernel
- update release notes and regression tests for the sysimage/depot contract

## Verification
- bash -n scripts/install-colab-julia.sh
- python -m unittest tests.test_verify_notebooks.RepositoryCommandTests
- make test-python PYTHON=python
- make test
- git diff --check

## Branch Hygiene
- Base: main
- Branch point: origin/main at dcb911a
- Stacked status: not stacked
- Prerequisites: none

Refs #10