### PR TITLE
Standardize Julia Colab setup across notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ long benchmark runs.
 
 | Topic | Julia notebook | Python notebook | Local verification status |
 | --- | --- | --- | --- |
-| Linear and Integer Programming | [notebooks_jl/1-MathProg.ipynb](notebooks_jl/1-MathProg.ipynb) | [notebooks_py/1-MathProg_python.ipynb](notebooks_py/1-MathProg_python.ipynb) | Requires local LP/NLP/MINLP solver binaries. |
+| Linear and Integer Programming | [notebooks_jl/1-MathProg.ipynb](notebooks_jl/1-MathProg.ipynb) | [notebooks_py/1-MathProg_python.ipynb](notebooks_py/1-MathProg_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; local execution requires LP/NLP/MINLP solver binaries. |
 | QUBO and Ising | [notebooks_jl/2-QUBO.ipynb](notebooks_jl/2-QUBO.ipynb) | [notebooks_py/2-QUBO_python.ipynb](notebooks_py/2-QUBO_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-qubo-python`. |
 | Graver Augmented Multiseed Algorithm | [notebooks_jl/3-GAMA.ipynb](notebooks_jl/3-GAMA.ipynb) | [notebooks_py/3-GAMA_python.ipynb](notebooks_py/3-GAMA_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-gama-python`. |
-| D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Requires D-Wave solver access for quantum annealer cells. |
-| Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Long-running benchmark notebook with generated artifacts. |
+| D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; quantum annealer cells require D-Wave solver access. |
+| Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; benchmark runs are long-running and generate artifacts. |
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
 
 ## Local verification
@@ -72,8 +72,8 @@ external solver credentials or longer-running jobs; those targets are not part
 of the default portable subset. The QCi notebook does not yet have a locked
 local make target because `eqc-models==0.19.0` requires `networkx<3`, which
 conflicts with the D-Wave Ocean stack.
-The Julia QUBO and GAMA notebooks use `scripts/install-colab-julia.sh` in Colab
-to install Julia and the latest precompiled QUBONotebooks sysimage.
+The Julia notebooks use `scripts/install-colab-julia.sh` in Colab to install
+Julia and the latest precompiled QUBONotebooks sysimage.
 
 ```bash
 make verify-notebooks NOTEBOOKS="notebooks_py/2-QUBO_python.ipynb" UV_GROUP_FLAGS="--group docs --group qubo"

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -37,6 +37,30 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Colab Instructions\n",
+        "\n",
+        "If not in a Colab notebook, continue to the next section.\n",
+        "\n",
+        "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
+        "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
+        "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%shell\n",
+        "\n",
+        "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+      ]
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "metadata": {},

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -32,6 +32,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a name=\"installation\" id=\"installation\"></a>\n",
+    "\n",
+    "## Colab Instructions\n",
+    "\n",
+    "If not in a Colab notebook, continue to the next section.\n",
+    "\n",
+    "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
+    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
+    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%shell\n",
+    "\n",
+    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -773,69 +799,6 @@
     "\n",
     "- [Julia Colab Notebook Template](https://colab.research.google.com/github/ageron/julia_notebooks/blob/master/Julia_Colab_Notebook_Template.ipynb)\n",
     "- [QuIPML22](https://github.com/bernalde/QuIPML22/)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a name=\"installation\" id=\"installation\"></a>\n",
-    "\n",
-    "# Installation\n",
-    "\n",
-    "## Colab Instructions\n",
-    "\n",
-    "If not in a Colab notebook, continue to the next section.\n",
-    "\n",
-    "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_ (you will need a Google account). Alternatively, you can download the notebook using _File_ > _Download .ipynb_, then upload it to [Colab](https://colab.research.google.com/).\n",
-    "2. Execute the following cell (click on it and press Ctrl+Enter) to install Julia, IJulia and other required packages. This can take a couple of minutes.\n",
-    "3. Reload this page (press Ctrl+R, or ⌘+R, or the F5 key) and continue to the next section.\n",
-    "\n",
-    "If your Colab Runtime gets reset (e.g., due to inactivity), repeat steps 2 and 3."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-30T19:03:51.177000Z",
-     "iopub.status.busy": "2026-06-30T19:03:51.177000Z",
-     "iopub.status.idle": "2026-06-30T19:03:51.352000Z",
-     "shell.execute_reply": "2026-06-30T19:03:51.352000Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "Unrecognized magic \\texttt{\\%\\%shell}.\n",
-       "\n",
-       "Julia does not use the IPython \\texttt{\\%magic} syntax.   To interact with the IJulia kernel, use \\texttt{IJulia.somefunction(...)}, for example.  Julia macros, string macros, and functions can be used to accomplish most of the other functionalities of IPython magics.\n",
-       "\n"
-      ],
-      "text/markdown": [
-       "Unrecognized magic `%%shell`.\n",
-       "\n",
-       "Julia does not use the IPython `%magic` syntax.   To interact with the IJulia kernel, use `IJulia.somefunction(...)`, for example.  Julia macros, string macros, and functions can be used to accomplish most of the other functionalities of IPython magics.\n"
-      ],
-      "text/plain": [
-       "  Unrecognized magic \u001b[36m%%shell\u001b[39m.\n",
-       "\n",
-       "  Julia does not use the IPython \u001b[36m%magic\u001b[39m syntax. To interact with the IJulia\n",
-       "  kernel, use \u001b[36mIJulia.somefunction(...)\u001b[39m, for example. Julia macros, string\n",
-       "  macros, and functions can be used to accomplish most of the other\n",
-       "  functionalities of IPython magics."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%shell\n",
-    "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
    ]
   },
   {

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -34,6 +34,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Colab Instructions\n",
+    "\n",
+    "If not in a Colab notebook, continue to the next section.\n",
+    "\n",
+    "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
+    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
+    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%shell\n",
+    "\n",
+    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -17,8 +17,11 @@ GAMA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "3-GAMA_python.ipynb"
 DWAVE_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb"
 DWAVE_PYTHON_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "4-DWAVE_python.ipynb"
 JULIA_COLAB_NOTEBOOK_PATHS = (
-    QUBO_JULIA_NOTEBOOK_PATH,
-    GAMA_JULIA_NOTEBOOK_PATH,
+    REPO_ROOT / "notebooks_jl" / "1-MathProg.ipynb",
+    REPO_ROOT / "notebooks_jl" / "2-QUBO.ipynb",
+    REPO_ROOT / "notebooks_jl" / "3-GAMA.ipynb",
+    REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb",
+    REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb",
 )
 COLAB_JULIA_INSTALLER = (
     'bash <(curl -s "https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/'
@@ -299,19 +302,21 @@ class RepositoryCommandTests(unittest.TestCase):
 
 
 class JuliaColabSetupTests(unittest.TestCase):
-    def test_julia_qubo_and_gama_notebooks_install_colab_julia_before_activation(self) -> None:
+    def test_all_julia_notebooks_install_colab_julia_before_activation(self) -> None:
         for path in JULIA_COLAB_NOTEBOOK_PATHS:
             with self.subTest(path=path.relative_to(REPO_ROOT).as_posix()):
                 cells = notebook_cell_sources(path)
-                install_index = next(
+                install_indexes = [
                     i for i, source in enumerate(cells) if COLAB_JULIA_INSTALLER in source
-                )
-                activate_index = next(
+                ]
+                activate_indexes = [
                     i for i, source in enumerate(cells) if "Pkg.activate(@__DIR__)" in source
-                )
+                ]
 
-                self.assertLess(install_index, activate_index)
-                self.assertIn("precompiled QUBONotebooks sysimage", cells[install_index - 1])
+                self.assertEqual([2], install_indexes)
+                self.assertTrue(activate_indexes)
+                self.assertLess(install_indexes[0], min(activate_indexes))
+                self.assertIn("precompiled QUBONotebooks sysimage", cells[install_indexes[0] - 1])
 
 
 class GamaNotebookTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add the shared Colab sysimage installer to Julia notebooks 1 and 5
- move notebook 4's Colab installer before activation and remove its stale late installer cell/output
- update README status text and require every Julia notebook to install the shared Colab setup before activation

## Verification
- python -m unittest tests.test_verify_notebooks.JuliaColabSetupTests tests.test_verify_notebooks.RepositoryCommandTests
- python - <<'PY' JSON parse check for notebooks_jl/*.ipynb
- make test-python PYTHON=python
- make test
- make test-julia
- git diff --check

## Notes
- This does not make credentialed D-Wave cells or long benchmarking runs part of the portable CI subset; it only standardizes the Colab bootstrap path across Julia notebooks.