### PR TITLE
Fix Python notebook dependency guards

### DIFF
--- a/notebooks_py/2-QUBO_python.ipynb
+++ b/notebooks_py/2-QUBO_python.ipynb
@@ -93,7 +93,7 @@
     "# Let's install dimod, neal, and pyomo\n",
     "if IN_COLAB:\n",
     "    !pip install -q pyomo\n",
-    "    !pip install dimod\n",
+    "    !pip install dimod scipy\n",
     "    !pip install dwave-neal"
    ]
   },

--- a/notebooks_py/3-GAMA_python.ipynb
+++ b/notebooks_py/3-GAMA_python.ipynb
@@ -678,12 +678,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's install with dimod and neal\n",
-    "if IN_COLAB:\n",
-    "    !pip install dimod\n",
-    "    !pip install dwave-neal\n",
-    "import dimod\n",
-    "import neal"
+    "# Ensure dimod and neal are available before building feasible starts.\n",
+    "try:\n",
+    "    import dimod\n",
+    "    import neal\n",
+    "except ImportError:\n",
+    "    import subprocess\n",
+    "    import sys\n",
+    "\n",
+    "    print(\"Installing dimod and dwave-neal for this notebook...\")\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"dimod\", \"dwave-neal\"])\n",
+    "    import dimod\n",
+    "    import neal"
    ]
   },
   {

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "scripts" / "verify_notebooks.py"
 QUBO_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "2-QUBO.ipynb"
+QUBO_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "2-QUBO_python.ipynb"
 GAMA_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "3-GAMA.ipynb"
 GAMA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "3-GAMA_python.ipynb"
 DWAVE_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb"
@@ -247,6 +248,15 @@ class RepositoryCommandTests(unittest.TestCase):
         self.assertNotIn('name = "diskcache"', lock)
         self.assertIn("GHSA-w8v5-vhqr-4h9v", (REPO_ROOT / "README.md").read_text())
 
+    def test_qubo_dependency_group_includes_notebook_runtime_packages(self) -> None:
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+        qubo_group = pyproject[
+            pyproject.index("qubo = [") : pyproject.index("\n]\n\n[tool.uv]")
+        ]
+
+        self.assertIn('"dimod>=0.12,<1"', qubo_group)
+        self.assertIn('"dwave-neal>=0.6,<1"', qubo_group)
+
     def test_sysimage_scripts_use_current_julia_notebook_project(self) -> None:
         create_sysimage = (REPO_ROOT / "scripts" / "create_sysimage.jl").read_text()
         prepare_release = (REPO_ROOT / "scripts" / "prepare_release.jl").read_text()
@@ -325,6 +335,26 @@ class JuliaColabSetupTests(unittest.TestCase):
                 self.assertTrue(activate_indexes)
                 self.assertLess(install_indexes[0], min(activate_indexes))
                 self.assertIn("precompiled QUBONotebooks sysimage", cells[install_indexes[0] - 1])
+
+
+class PythonNotebookDependencySetupTests(unittest.TestCase):
+    def test_qubo_colab_install_includes_scipy_before_imports(self) -> None:
+        cells = notebook_cell_sources(QUBO_NOTEBOOK_PATH)
+        install_cell = notebook_cell_source(QUBO_NOTEBOOK_PATH, "!pip install -q pyomo")
+        import_cell = notebook_cell_source(QUBO_NOTEBOOK_PATH, "from scipy.special import gamma")
+
+        self.assertIn("!pip install dimod scipy", install_cell)
+        self.assertLess(cells.index(install_cell), cells.index(import_cell))
+
+    def test_gama_installs_missing_dimod_and_neal_outside_colab(self) -> None:
+        install_cell = notebook_cell_source(GAMA_NOTEBOOK_PATH, "subprocess.check_call")
+
+        self.assertIn("try:\n    import dimod\n    import neal", install_cell)
+        self.assertIn(
+            '[sys.executable, "-m", "pip", "install", "dimod", "dwave-neal"]',
+            install_cell,
+        )
+        self.assertNotIn("if IN_COLAB", install_cell)
 
 
 class GamaNotebookTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Adds `scipy` to the QUBO notebook Colab dependency install cell before the unconditional `scipy` import.
- Replaces the GAMA notebook's Colab-only `dimod`/`neal` setup with a local/Colab import guard that installs `dimod` and `dwave-neal` when missing.
- Adds notebook-source regression tests for the install cells and verifies the `qubo` dependency group already includes `dimod` and `dwave-neal`.

Notebook source outputs were intentionally not committed; repository verification writes executed copies to ignored `.nbverify/` outputs.

Closes #36

## Tests

- `python -m unittest tests.test_verify_notebooks.PythonNotebookDependencySetupTests tests.test_verify_notebooks.RepositoryCommandTests.test_qubo_dependency_group_includes_notebook_runtime_packages tests.test_verify_notebooks.GamaNotebookTests.test_gama_notebook_source_outputs_are_cleared`
- `python -m unittest discover -s tests`
- `make verify-qubo-python`
- `make verify-gama-python`
- Fresh venv smoke: `dimod`/`neal` initially absent, GAMA guard installed `dimod` and `dwave-neal`, then imported both successfully.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `04046afe1ee64d47a393b21d2edeaf3e647436e1`
- Stacked status: standalone PR, no prerequisite PRs.
