### PR TITLE
Fix Julia benchmarking results zip handling

### DIFF
--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -20822,7 +20822,28 @@
     "use_raw_data      = false\n",
     "\n",
     "if isfile(zip_name) && use_raw_data\n",
-    "    run(`gzip -d $pickle_path`)\n",
+    "    destination = abspath(pickle_path)\n",
+    "    zr = ZipFile.Reader(zip_name)\n",
+    "\n",
+    "    try\n",
+    "        for f in zr.files\n",
+    "            file_path = normpath(joinpath(destination, f.name))\n",
+    "            relative_path = relpath(file_path, destination)\n",
+    "\n",
+    "            if relative_path == \"..\" || startswith(relative_path, \"../\") || startswith(relative_path, \"..\\\\\")\n",
+    "                error(\"Refusing to extract '$(f.name)' outside '$destination'\")\n",
+    "            end\n",
+    "\n",
+    "            if endswith(f.name, \"/\")\n",
+    "                mkpath(file_path)\n",
+    "            else\n",
+    "                mkpath(dirname(file_path))\n",
+    "                write(file_path, read(f))\n",
+    "            end\n",
+    "        end\n",
+    "    finally\n",
+    "        close(zr)\n",
+    "    end\n",
     "\n",
     "    @info(\"Results zip file has been extracted to '$pickle_path'\")\n",
     "end"
@@ -23787,23 +23808,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "zip(\"/home/jvpcms/purdue-internship/QUBONotebooksFork/notebooks_jl/results\", \"/home/jvpcms/purdue-internship/QUBONotebooksFork/notebooks_jl/results.zip\")"
-      ]
-     },
-     "execution_count": 162,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# zip the results folder\n",
-    "zip(pickle_path, pickle_path * \".zip\")"
+    "zip_name = joinpath(pickle_path, \"results.zip\")\n",
+    "\n",
+    "w = ZipFile.Writer(zip_name)\n",
+    "\n",
+    "try\n",
+    "    for file_name in sort(readdir(pickle_path))\n",
+    "        file_path = joinpath(pickle_path, file_name)\n",
+    "\n",
+    "        if isfile(file_path) && abspath(file_path) != abspath(zip_name)\n",
+    "            f = ZipFile.addfile(w, file_name)\n",
+    "            write(f, read(file_path))\n",
+    "        end\n",
+    "    end\n",
+    "finally\n",
+    "    close(w)\n",
+    "end"
    ]
   },
   {

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -17,6 +17,7 @@ GAMA_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "3-GAMA.ipynb"
 GAMA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "3-GAMA_python.ipynb"
 DWAVE_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb"
 DWAVE_PYTHON_NOTEBOOK_PATH = REPO_ROOT / "notebooks_py" / "4-DWAVE_python.ipynb"
+BENCHMARKING_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb"
 JULIA_COLAB_NOTEBOOK_PATHS = (
     REPO_ROOT / "notebooks_jl" / "1-MathProg.ipynb",
     REPO_ROOT / "notebooks_jl" / "2-QUBO.ipynb",
@@ -77,6 +78,31 @@ class NotebookSourceSafetyTests(unittest.TestCase):
         ]
 
         self.assertEqual([], offenders)
+
+
+class BenchmarkingNotebookArchiveTests(unittest.TestCase):
+    def test_raw_results_zip_is_extracted_with_zipfile(self) -> None:
+        source = notebook_cell_source(BENCHMARKING_JULIA_NOTEBOOK_PATH, "use_raw_data")
+
+        self.assertIn("ZipFile.Reader(zip_name)", source)
+        self.assertIn("for f in zr.files", source)
+        self.assertIn("relpath(file_path, destination)", source)
+        self.assertIn("Refusing to extract", source)
+        self.assertIn("write(file_path, read(f))", source)
+        self.assertNotIn("gzip", source)
+        self.assertNotIn("run(`", source)
+
+    def test_results_archive_is_written_with_zipfile(self) -> None:
+        source = notebook_cell_source(
+            BENCHMARKING_JULIA_NOTEBOOK_PATH,
+            "# zip the results folder",
+        )
+
+        self.assertIn('joinpath(pickle_path, "results.zip")', source)
+        self.assertIn("ZipFile.Writer(zip_name)", source)
+        self.assertIn("ZipFile.addfile(w, file_name)", source)
+        self.assertIn("write(f, read(file_path))", source)
+        self.assertNotIn("zip(pickle_path", source)
 
 
 class ParseExecutionTimeoutSecondsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Replace the Julia benchmarking notebook's raw-data `gzip` shell call with `ZipFile.Reader` extraction of `results/results.zip`.
- Replace the result-folder `zip(...)` iterator call with `ZipFile.Writer` archive creation for `results/results.zip`.
- Add unit tests that guard the affected notebook cells against regressing to shell `gzip` or Julia's iterator `zip`.

Closes #37

## Testing

- `python -m unittest tests.test_verify_notebooks.BenchmarkingNotebookArchiveTests`
- `julia --project=./notebooks_jl --startup-file=no -e '...'` minimal ZipFile archive round-trip using the notebook logic
- `make test`
- `make test-python`
- `make test-julia`

The full benchmarking notebook was not re-executed because the repository documents it as long-running and artifact-generating.

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-37-benchmarking-zip`
- Branch point: `origin/main` at `71f8c19`
- Stacked status: not stacked
- Prerequisites: none
