### PR TITLE
Fix Ising ILP objective in QUBO notebook

### DIFF
--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -14255,6 +14255,17 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ising-qubo-substitution"
+      },
+      "source": [
+        "Before rebuilding the Ising model as a binary ILP, use the `QUBOTools.qubo` binary convention $s = 2x - 1$.\n",
+        "\n",
+        "Under this substitution, the Ising Hamiltonian becomes a QUBO with a separate linear vector $L$, a strictly off-diagonal quadratic matrix $Q$, and an offset $\\beta$. The scale and offset are already included in those returned pieces, so the ILP objective must include both the $L_i x_i$ terms and the off-diagonal $Q_{ij} y_{ij}$ terms."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": 27,
       "metadata": {
@@ -14295,7 +14306,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Min 96 y[1,4] + 96 y[1,5] + 96 y[1,6] + 96 y[1,8] + 96 y[1,9] + 96 y[1,10] + 96 y[1,11] + 96 y[2,4] + 96 y[2,6] + 96 y[2,7] + 96 y[2,9] + 96 y[2,10] + 96 y[2,11] + 96 y[3,5] + 96 y[3,7] + 96 y[3,8] + 96 y[3,9] + 96 y[3,10] + 96 y[3,11] + 96 y[4,5] + 192 y[4,6] + 96 y[4,7] + 96 y[4,8] + 192 y[4,9] + 192 y[4,10] + 192 y[4,11] + 96 y[5,6] + 96 y[5,7] + 192 y[5,8] + 192 y[5,9] + 192 y[5,10] + 192 y[5,11] + 96 y[6,7] + 96 y[6,8] + 192 y[6,9] + 192 y[6,10] + 192 y[6,11] + 96 y[7,8] + 192 y[7,9] + 192 y[7,10] + 192 y[7,11] + 192 y[8,9] + 192 y[8,10] + 192 y[8,11] + 288 y[9,10] + 288 y[9,11] + 288 y[10,11] + 144\n",
+            "Min -46 x[1] - 44 x[2] - 44 x[3] - 92 x[4] - 92 x[5] - 92 x[6] - 91 x[7] - 92 x[8] - 139 x[9] - 138 x[10] - 139 x[11] + 96 y[1,4] + 96 y[1,5] + 96 y[1,6] + 96 y[1,8] + 96 y[1,9] + 96 y[1,10] + 96 y[1,11] + 96 y[2,4] + 96 y[2,6] + 96 y[2,7] + 96 y[2,9] + 96 y[2,10] + 96 y[2,11] + 96 y[3,5] + 96 y[3,7] + 96 y[3,8] + 96 y[3,9] + 96 y[3,10] + 96 y[3,11] + 96 y[4,5] + 192 y[4,6] + 96 y[4,7] + 96 y[4,8] + 192 y[4,9] + 192 y[4,10] + 192 y[4,11] + 96 y[5,6] + 96 y[5,7] + 192 y[5,8] + 192 y[5,9] + 192 y[5,10] + 192 y[5,11] + 96 y[6,7] + 96 y[6,8] + 192 y[6,9] + 192 y[6,10] + 192 y[6,11] + 96 y[7,8] + 192 y[7,9] + 192 y[7,10] + 192 y[7,11] + 192 y[8,9] + 192 y[8,10] + 192 y[8,11] + 288 y[9,10] + 288 y[9,11] + 288 y[10,11] + 144\n",
             "Subject to\n",
             " c1[1,2] : -x[1] - x[2] + y[1,2] ≥ -1\n",
             " c1[1,3] : -x[1] - x[3] + y[1,3] ≥ -1\n",
@@ -14405,18 +14416,20 @@
       "source": [
         "ising_ilp_model = Model()\n",
         "\n",
-        "@variable(ising_ilp_model, x[1:11], Bin)\n",
-        "@variable(ising_ilp_model, y[1:11, 1:11], Bin)\n",
+        "@variable(ising_ilp_model, x[1:n], Bin)\n",
+        "@variable(ising_ilp_model, y[1:n, 1:n], Bin)\n",
         "\n",
         "@objective(\n",
         "    ising_ilp_model,\n",
         "    Min,\n",
-        "    sum(Q[i,j] * (i == j ? x[i] : y[i,j]) for i=1:11, j=1:11) +  β\n",
+        "    sum(L[i] * x[i] for i in 1:n) +\n",
+        "    sum(Q[i,j] * y[i,j] for i in 1:n, j in 1:n if i != j) +\n",
+        "    β\n",
         ")\n",
         "\n",
-        "@constraint(ising_ilp_model, c1[i=1:11,j=1:11;i!=j], y[i,j] >= x[i] + x[j] - 1)\n",
-        "@constraint(ising_ilp_model, c2[i=1:11,j=1:11;i!=j], y[i,j] <= x[i])\n",
-        "@constraint(ising_ilp_model, c3[i=1:11,j=1:11;i!=j], y[i,j] <= x[j])\n",
+        "@constraint(ising_ilp_model, c1[i=1:n,j=1:n;i!=j], y[i,j] >= x[i] + x[j] - 1)\n",
+        "@constraint(ising_ilp_model, c2[i=1:n,j=1:n;i!=j], y[i,j] <= x[i])\n",
+        "@constraint(ising_ilp_model, c3[i=1:n,j=1:n;i!=j], y[i,j] <= x[j])\n",
         "\n",
         "println(ising_ilp_model)"
       ]
@@ -14442,15 +14455,16 @@
             "│ ├ termination_status : OPTIMAL\n",
             "│ ├ result_count       : 1\n",
             "│ ├ raw_status         : Solution is optimal\n",
-            "│ └ objective_bound    : 1.44000e+02\n",
+            "│ └ objective_bound    : 5.00000e+00\n",
             "├ Solution (result = 1)\n",
             "│ ├ primal_status        : FEASIBLE_POINT\n",
             "│ ├ dual_status          : NO_SOLUTION\n",
-            "│ ├ objective_value      : 1.44000e+02\n",
-            "│ └ relative_gap         : 0.00000e+00\n",
+            "│ ├ objective_value      : 5.00000e+00\n",
+            "│ └ relative_gap         : 7.40000e+00\n",
             "└ Work counters\n",
-            "  └ solve_time (sec)   : 3.80993e-04\n",
-            "* x = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"
+            "  └ solve_time (sec)   : 6.16097e-03\n",
+            "* x = [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]\n",
+            "* s = [-1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1]\n"
           ]
         }
       ],
@@ -14460,9 +14474,14 @@
         "optimize!(ising_ilp_model)\n",
         "\n",
         "ising_ilp_x = round.(Int, value.(x))\n",
+        "ising_ilp_s = 2 .* ising_ilp_x .- 1\n",
+        "\n",
+        "@assert ising_ilp_s == ising_s\n",
+        "@assert isapprox(objective_value(ising_ilp_model), objective_value(ising_model); atol = 1e-6)\n",
         "\n",
         "println(solution_summary(ising_ilp_model))\n",
-        "println(\"* x = $ising_ilp_x\")"
+        "println(\"* x = $ising_ilp_x\")\n",
+        "println(\"* s = $ising_ilp_s\")"
       ]
     },
     {
@@ -14471,7 +14490,7 @@
         "id": "1VlhuVWA3n5n"
       },
       "source": [
-        "We observe that the optimal solution of this problem is $x_{1} = x_{2} = x_{3} = 1, 0$ otherwise, leading to an objective of $-38$."
+        "The corrected ILP solution is $x = [0,0,0,0,0,0,0,0,1,0,0]$, which maps back to $s = [-1,-1,-1,-1,-1,-1,-1,-1,+1,-1,-1]$ through $s = 2x - 1$. This matches the ExactSampler solution and gives objective value $5.0$."
       ]
     },
     {

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -105,6 +105,41 @@ class BenchmarkingNotebookArchiveTests(unittest.TestCase):
         self.assertNotIn("zip(pickle_path", source)
 
 
+class QUBOJuliaNotebookTests(unittest.TestCase):
+    def test_ising_ilp_objective_keeps_linear_and_quadratic_terms_separate(self) -> None:
+        source = notebook_cell_source(QUBO_JULIA_NOTEBOOK_PATH, "ising_ilp_model = Model()")
+
+        self.assertIn("@variable(ising_ilp_model, x[1:n], Bin)", source)
+        self.assertIn("@variable(ising_ilp_model, y[1:n, 1:n], Bin)", source)
+        self.assertIn("sum(L[i] * x[i] for i in 1:n)", source)
+        self.assertIn("sum(Q[i,j] * y[i,j] for i in 1:n, j in 1:n if i != j)", source)
+        self.assertNotIn("i == j ? x[i] : y[i,j]", source)
+
+    def test_ising_ilp_solution_is_checked_against_exact_sampler(self) -> None:
+        source = notebook_cell_source(QUBO_JULIA_NOTEBOOK_PATH, "ising_ilp_x = round")
+
+        self.assertIn("ising_ilp_s = 2 .* ising_ilp_x .- 1", source)
+        self.assertIn("@assert ising_ilp_s == ising_s", source)
+        self.assertIn(
+            "@assert isapprox(objective_value(ising_ilp_model), objective_value(ising_model); atol = 1e-6)",
+            source,
+        )
+
+    def test_ising_ilp_markdown_documents_substitution_and_correct_result(self) -> None:
+        substitution = notebook_cell_source(
+            QUBO_JULIA_NOTEBOOK_PATH,
+            "Before rebuilding the Ising model as a binary ILP",
+        )
+        result = notebook_cell_source(QUBO_JULIA_NOTEBOOK_PATH, "The corrected ILP solution")
+
+        self.assertIn("$s = 2x - 1$", substitution)
+        self.assertIn("linear vector $L$", substitution)
+        self.assertIn("strictly off-diagonal quadratic matrix $Q$", substitution)
+        self.assertIn("$x = [0,0,0,0,0,0,0,0,1,0,0]$", result)
+        self.assertIn("$s = [-1,-1,-1,-1,-1,-1,-1,-1,+1,-1,-1]$", result)
+        self.assertIn("objective value $5.0$", result)
+
+
 class ParseExecutionTimeoutSecondsTests(unittest.TestCase):
     def test_uses_default_timeout_when_env_is_unset(self) -> None:
         with patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## Summary

- Fixes the Ising ILP objective in `notebooks_jl/2-QUBO.ipynb` so it includes `L[i] * x[i]` linear terms and only uses off-diagonal `Q[i,j] * y[i,j]` quadratic terms.
- Adds a markdown note explaining the verified `QUBOTools.qubo` binary convention, `s = 2x - 1`, and updates the notebook output/result text to the corrected GLPK solution.
- Adds source-level regression tests to prevent the missing-linear-term objective and to require the ILP solution/objective comparison against `ExactSampler`.

Closes #38

## Verification

- `make test`
- `make test-python`
- `JULIA_DEPOT_PATH=/home/bernalde/repos/QUBONotebooks/.julia-depot:/home/bernalde/.julia JULIA_PKG_PRECOMPILE_AUTO=0 make test-julia`
- Targeted Julia reproduction of the affected Ising cells: GLPK returns `x = [0,0,0,0,0,0,0,0,1,0,0]`, maps to `s = [-1,-1,-1,-1,-1,-1,-1,-1,+1,-1,-1]`, and matches the `ExactSampler` objective `5.0`.

`QUBOTools.qubo` was verified locally to use `s = 2x - 1`; using `s = 1 - 2x` does not match the returned binary solution for this notebook.

I also attempted full execution with:

`UV_CACHE_DIR=/home/bernalde/repos/QUBONotebooks/.uv-cache timeout 10m uv run --locked --group docs python ./scripts/verify_notebooks.py notebooks_jl/2-QUBO.ipynb`

That verifier executed under Jupyter but failed later in the notebook on an unrelated existing `backend(color_model)` ambiguity between `Plots` and `JuMP`.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `5086bbf64c98bce291f776ada3867012159ea641`
- Stacked status: standalone
- Prerequisite PRs: none
