### PR TITLE
Replace graph coloring CSP with manual BQM

### DIFF
--- a/notebooks_py/2-QUBO_python.ipynb
+++ b/notebooks_py/2-QUBO_python.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "## Quadratic Unconstrained Binary Optimization\n",
     "This notebook will explain the basics of the QUBO modeling. In order to implement the different QUBOs we will use D-Wave's packages **[dimod](https://github.com/dwavesystems/dimod)**, and then solve them using **[neal](https://github.com/dwavesystems/dwave-neal)**'s implementation of simulated annealing.\n",
-    "We will also leverage the use of D-Wave's package **[dwavebinarycsp](https://github.com/dwavesystems/dwavebinarycsp)** to translate constraint satisfaction problems to QUBOs. Finally, for Groebner basis computations we will use **[Sympy](https://www.sympy.org/)** for symbolic computation in Python and **[Networkx](https://networkx.github.io/)** for network models/graphs."
+    "For Groebner basis computations we will use **[Sympy](https://www.sympy.org/)** for symbolic computation in Python and **[Networkx](https://networkx.github.io/)** for network models/graphs."
    ]
   },
   {
@@ -666,13 +666,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's install with dimod and neal\n",
-    "if IN_COLAB:\n",
-    "    !pip install dwavebinarycsp\n",
-    "    !pip install dwavebinarycsp[maxgap]\n",
-    "    !pip install dwavebinarycsp[mip]\n",
-    "\n",
-    "import dwavebinarycsp"
+    "# The graph coloring QUBO below uses dimod directly; no CSP package is required."
    ]
   },
   {
@@ -699,36 +693,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Function for the constraint that two nodes with a shared edge not both select\n",
-    "# one color\n",
-    "def not_both_1(v, u):\n",
-    "    return not (v and u)\n",
+    "colors = 3\n",
+    "exactly_one_penalty = 1.0\n",
+    "edge_penalty = 1.0\n",
     "\n",
-    "# Valid configurations for the constraint that each node select a single color, in this case we want to use 3 colors\n",
-    "one_color_configurations = {(0, 0, 1), (0, 1, 0), (1, 0, 0)}\n",
-    "colors = len(one_color_configurations)\n",
+    "def color_var(node, color):\n",
+    "    return f'x{node},{color}'\n",
     "\n",
-    "# Create a binary constraint satisfaction problem\n",
-    "csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)\n",
+    "def build_graph_coloring_bqm(\n",
+    "    nodes,\n",
+    "    edges,\n",
+    "    colors,\n",
+    "    exactly_one_penalty=1.0,\n",
+    "    edge_penalty=1.0,\n",
+    "):\n",
+    "    bqm = dimod.BinaryQuadraticModel({}, {}, 0.0, dimod.BINARY)\n",
     "\n",
-    "# Add constraint that each node select a single color\n",
-    "for node in V:\n",
-    "    variables = ['x'+str(node)+','+str(i) for i in range(colors)]\n",
-    "    csp.add_constraint(one_color_configurations, variables)\n",
+    "    # Add A * (1 - sum_c x_{v,c})^2 for each node v.\n",
+    "    for node in nodes:\n",
+    "        variables = [color_var(node, color) for color in range(colors)]\n",
+    "        bqm.offset += exactly_one_penalty\n",
+    "        for variable in variables:\n",
+    "            bqm.add_linear(variable, -exactly_one_penalty)\n",
+    "        for first in range(colors):\n",
+    "            for second in range(first + 1, colors):\n",
+    "                bqm.add_quadratic(\n",
+    "                    variables[first],\n",
+    "                    variables[second],\n",
+    "                    2 * exactly_one_penalty,\n",
+    "                )\n",
     "\n",
-    "# Add constraint that each pair of nodes with a shared edge not both select one color\n",
-    "for edge in E:\n",
-    "    v, u = edge\n",
-    "    for i in range(colors):\n",
-    "        variables = ['x'+str(v)+','+str(i), 'x'+str(u)+','+str(i)]\n",
-    "        csp.add_constraint(not_both_1, variables)"
+    "    # Add B * x_{u,c} * x_{v,c} for each edge (u, v) and color c.\n",
+    "    for v, u in edges:\n",
+    "        for color in range(colors):\n",
+    "            bqm.add_quadratic(color_var(v, color), color_var(u, color), edge_penalty)\n",
+    "\n",
+    "    return bqm\n",
+    "\n",
+    "def is_valid_coloring(sample):\n",
+    "    for node in V:\n",
+    "        selected = [color for color in range(colors) if sample[color_var(node, color)]]\n",
+    "        if len(selected) != 1:\n",
+    "            return False\n",
+    "\n",
+    "    for v, u in E:\n",
+    "        for color in range(colors):\n",
+    "            if sample[color_var(v, color)] and sample[color_var(u, color)]:\n",
+    "                return False\n",
+    "\n",
+    "    return True"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Defining the Binary Quandratic model (QUBO) using the CSP library we have:"
+    "Defining the Binary Quadratic Model (QUBO) directly from the graph coloring penalties we have:"
    ]
   },
   {
@@ -737,8 +757,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bqm = dwavebinarycsp.stitch(csp)\n",
-    "simAnnSamples = simAnnSampler.sample(bqm, num_reads=1000)"
+    "bqm = build_graph_coloring_bqm(V, E, colors, exactly_one_penalty, edge_penalty)\n",
+    "simAnnSamples = simAnnSampler.sample(bqm, num_reads=2000, num_sweeps=1000)"
    ]
   },
   {
@@ -755,7 +775,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because of precision issues in the translation to BQM, we *may* obtain very tiny coefficeints that should be zero. In any case, since this is a constraint satisfaction problem, any of the solutions with energy ~0 is a valid coloring."
+    "With this direct penalty model, every feasible 3-coloring has energy 0. Any sample with positive energy violates at least one exactly-one-color or adjacent-color constraint."
    ]
   },
   {
@@ -765,11 +785,16 @@
    "outputs": [],
    "source": [
     "# Check that a good solution was found\n",
-    "sample = simAnnSamples.first.sample     # doctest: +SKIP\n",
-    "if not csp.check(sample):           # doctest: +SKIP\n",
-    "        print(\"Failed to color map. Try sampling again.\")\n",
+    "sample = None\n",
+    "for datum in simAnnSamples.data(['sample'], sorted_by='energy'):\n",
+    "    if is_valid_coloring(datum.sample):\n",
+    "        sample = datum.sample\n",
+    "        break\n",
+    "\n",
+    "if sample is None:\n",
+    "    raise RuntimeError(\"Failed to color map. Try sampling again.\")\n",
     "else:\n",
-    "        print(sample)"
+    "    print(sample)"
    ]
   },
   {
@@ -784,7 +809,7 @@
     "    color_map = {}\n",
     "    for node in V:\n",
     "          for i in range(colors):\n",
-    "            if sample['x'+str(node)+','+str(i)]:\n",
+    "            if sample[color_var(node, i)]:\n",
     "                color_map[node] = i\n",
     "    # Plot the sample with color-coded nodes\n",
     "    node_colors = [color_map.get(node) for node in G.nodes()]\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ mathprog = [
 qubo = [
     "dimod>=0.12,<1",
     "dwave-neal>=0.6,<1",
-    "dwavebinarycsp[maxgap,mip]>=0.3.1,<1",
     "highspy>=1.15.1,<2",
     "matplotlib>=3.8,<4",
     "networkx>=3.3,<4",

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -124,6 +124,37 @@ class PythonPlotSamplesNotebookTests(unittest.TestCase):
         )
 
 
+class QUBOPythonGraphColoringTests(unittest.TestCase):
+    def test_graph_coloring_uses_manual_dimod_bqm(self) -> None:
+        source = notebook_source(QUBO_NOTEBOOK_PATH)
+        bqm_source = notebook_cell_source(
+            QUBO_NOTEBOOK_PATH,
+            "def build_graph_coloring_bqm",
+        )
+
+        self.assertNotIn("dwavebinarycsp", source)
+        self.assertIn("dimod.BinaryQuadraticModel", bqm_source)
+        self.assertIn("bqm.offset += exactly_one_penalty", bqm_source)
+        self.assertIn("bqm.add_linear(variable, -exactly_one_penalty)", bqm_source)
+        self.assertIn("2 * exactly_one_penalty", bqm_source)
+        self.assertIn("edge_penalty", bqm_source)
+
+    def test_graph_coloring_validates_samples_without_csp_package(self) -> None:
+        validator_source = notebook_cell_source(
+            QUBO_NOTEBOOK_PATH,
+            "def is_valid_coloring",
+        )
+        sampling_source = notebook_cell_source(QUBO_NOTEBOOK_PATH, "sample = None")
+
+        self.assertIn("len(selected) != 1", validator_source)
+        self.assertIn(
+            "sample[color_var(v, color)] and sample[color_var(u, color)]",
+            validator_source,
+        )
+        self.assertIn("is_valid_coloring(datum.sample)", sampling_source)
+        self.assertNotIn("csp.check", sampling_source)
+
+
 class BenchmarkingNotebookArchiveTests(unittest.TestCase):
     def test_python_results_zip_uses_local_cache_path(self) -> None:
         source = notebook_cell_source(BENCHMARKING_PYTHON_NOTEBOOK_PATH, "bundled_zip")
@@ -596,6 +627,8 @@ class RepositoryCommandTests(unittest.TestCase):
 
         self.assertNotIn("dwave-ocean-sdk", pyproject)
         self.assertNotIn("dwave-ocean-sdk", lock)
+        self.assertNotIn("dwavebinarycsp", pyproject)
+        self.assertNotIn("dwavebinarycsp", lock)
         self.assertNotIn('name = "diskcache"', lock)
         self.assertIn("GHSA-w8v5-vhqr-4h9v", (REPO_ROOT / "README.md").read_text())
 

--- a/uv.lock
+++ b/uv.lock
@@ -364,21 +364,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dwavebinarycsp"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dimod" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "penaltymodel" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/8b/18e3c027be5fc58bfb39c57686332e8b1c39a080386132aef2e8548467a5/dwavebinarycsp-0.3.1.tar.gz", hash = "sha256:7af07cd269809db94dbb4bee9b9cee437e9199fb42be6f2fcf68971a6f01bdbe", size = 29301, upload-time = "2024-11-27T23:00:40.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/fa/2b5616a53e0eabc194db45d5e1f5feea1ecf32aa4732af4c8892d15c8f21/dwavebinarycsp-0.3.1-py3-none-any.whl", hash = "sha256:a4a0f3d7f69fc43397467842d7056ac940ab3848ec55a8e2e412f464c864aadd", size = 35387, upload-time = "2024-11-27T23:00:39.002Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -506,15 +491,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/77/9a07df7181834cfb61dafa5594e5eedc78369797c6487806bd3221d20667/highspy-1.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dd9ee8e139e7260ec1306a48e30f1bd7937d9cfb8cb201d25da10e1099e5129b", size = 6636717, upload-time = "2026-07-02T12:02:18.72Z" },
     { url = "https://files.pythonhosted.org/packages/9a/25/5083d8e3d5cf5ff5edf5bcc03e3f693630ab59142c9d0a0bcbb2d315c50e/highspy-1.15.1-cp312-cp312-win32.whl", hash = "sha256:01c6585e83938ecf4139248b074b2ee736816d63716a20dc608b1d2fc9637b66", size = 2306753, upload-time = "2026-07-02T12:02:20.837Z" },
     { url = "https://files.pythonhosted.org/packages/d4/01/05521ca6b38e34e68d707888c378d3bcac34e62715b739e7c0c9b9887993/highspy-1.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:8c548165270608a40147a7ea6d985fd62a65fabf0f075b3c0c59ea910b724223", size = 2711114, upload-time = "2026-07-02T12:02:22.621Z" },
-]
-
-[[package]]
-name = "homebase"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/fa/55afcae0026285dc51792e5959b3667a246fd5cb82e97211f2267d52b3ac/homebase-1.0.1.tar.gz", hash = "sha256:9ee008df4298b420852d815e6df488822229c4bd8d571bcd0a454e04232c635e", size = 11848, upload-time = "2018-07-30T22:48:52.764Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/ad/e0080c35bd177682d5118a95bc2e7c1ac0541394b4ffce5e9554b6a077f9/homebase-1.0.1-py2.py3-none-any.whl", hash = "sha256:d64c97f60a8ddd94ce8702bac65ed5d1996aca01a17d1e53e6ad5149e2f8b5b5", size = 11307, upload-time = "2018-07-30T22:48:51.551Z" },
 ]
 
 [[package]]
@@ -1214,27 +1190,6 @@ wheels = [
 ]
 
 [[package]]
-name = "penaltymodel"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dimod" },
-    { name = "homebase" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/f6/3af591b63fca93de731711f8c985e5b7f5ef97de28e334ffeec413c31c82/penaltymodel-1.3.0.tar.gz", hash = "sha256:34af628916420218b16a8ceca608abbf8530b731fe05902392a3a3bceee395d0", size = 32231, upload-time = "2025-08-26T16:27:26.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/16/501a538776abb83ef02243e937fb7b196a7377e49bb474798ca8bc5a58a6/penaltymodel-1.3.0-py3-none-any.whl", hash = "sha256:543f596a5c1fb602d18355c46349e8ccb2842b335de86958d7525de0d993eda9", size = 36133, upload-time = "2025-08-26T16:27:25.868Z" },
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1649,7 +1604,6 @@ mathprog = [
 qubo = [
     { name = "dimod" },
     { name = "dwave-neal" },
-    { name = "dwavebinarycsp" },
     { name = "highspy" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1685,7 +1639,6 @@ mathprog = [
 qubo = [
     { name = "dimod", specifier = ">=0.12,<1" },
     { name = "dwave-neal", specifier = ">=0.6,<1" },
-    { name = "dwavebinarycsp", extras = ["maxgap", "mip"], specifier = ">=0.3.1,<1" },
     { name = "highspy", specifier = ">=1.15.1,<2" },
     { name = "matplotlib", specifier = ">=3.8,<4" },
     { name = "networkx", specifier = ">=3.3,<4" },


### PR DESCRIPTION
## Summary

- Replaces the graph-coloring `dwavebinarycsp` workflow in `notebooks_py/2-QUBO_python.ipynb` with a direct `dimod.BinaryQuadraticModel` formulation.
- Removes `dwavebinarycsp[maxgap,mip]` from the QUBO dependency group and refreshes `uv.lock`.
- Adds source-level regression tests that reject the deprecated CSP package path and verify the manual BQM/sample-validation code remains in the notebook.

Closes #53

## Tests

- `pytest tests/test_verify_notebooks.py -q`
- `make verify-qubo-python`

## Notebook Outputs

The committed notebook remains source-only for the edited cells. Local notebook execution was verified through the repository verifier, which writes executed copies under `.nbverify/`; those generated outputs are not committed.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `e34398a8d6fcd21e21156e57ae326a51502a6e4d`
- Stacked status: not stacked
- Prerequisite PRs: none
