### PR TITLE
Warn about benchmarking cache download

### DIFF
--- a/notebooks_py/5-Benchmarking_python.ipynb
+++ b/notebooks_py/5-Benchmarking_python.ipynb
@@ -1049,7 +1049,8 @@
    "metadata": {},
    "source": [
     "Before figuring out if we have the right optimal parameters, we want to save some effort by loading previously computed results.\n",
-    "If you do not want to load the results that we are providing, feel free to change the `overwrite_pickles` variable, at the expense that it will take some time (around 10 minutes per instance) to run.\n",
+    "Run the next cell to download the precomputed benchmark cache before continuing.\n",
+    "Skipping this download, or changing `overwrite_pickles` to regenerate the data, can trigger approximately 3 hours of local computation.\n",
     "Otherwise, a zip file with precomputed results will be downloaded from github."
    ]
   },

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -166,6 +166,15 @@ class BenchmarkingNotebookArchiveTests(unittest.TestCase):
         self.assertIn("urlretrieve(", source)
         self.assertNotIn("/content/results/results.zip", source)
 
+    def test_python_results_zip_warns_before_expensive_regeneration(self) -> None:
+        source = notebook_cell_source(
+            BENCHMARKING_PYTHON_NOTEBOOK_PATH,
+            "precomputed benchmark cache",
+        )
+
+        self.assertIn("approximately 3 hours of local computation", source)
+        self.assertIn("Run the next cell to download", source)
+
     def test_raw_results_zip_is_extracted_with_zipfile(self) -> None:
         source = notebook_cell_source(BENCHMARKING_JULIA_NOTEBOOK_PATH, "use_raw_data")
 


### PR DESCRIPTION
## Summary

- Adds an explicit warning before the Python benchmarking cache download that skipping it can trigger approximately 3 hours of local recomputation.
- Keeps the existing portable `pickle_path` download/load behavior on `main`; the hardcoded `/content/results` path is already absent there.
- Adds source-level regression coverage so the warning stays with the cache-download cell.

Closes #54

## Tests

- `pytest tests/test_verify_notebooks.py -k BenchmarkingNotebookArchiveTests`
- `make test-python`
- `make test`
- Targeted outside-Colab smoke: executed the notebook download/extract cells in a temporary directory with `urlretrieve` patched to create a valid results archive, confirmed `pickle_path` resolved to local `results/`, extracted `results.zip`, and loaded `results_42.pkl`.

Full benchmarking notebook execution was not re-run because this PR changes Markdown only and the notebook benchmark path is intentionally long-running.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `d80b4c2c6932ac4eff17fb467cb95b5223917c08`
- Stacked status: not stacked
- Prerequisite PRs: none
