### PR TITLE
Add notebook learning objectives and summaries

### DIFF
--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -40,6 +40,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Formulate linear, integer, convex nonlinear, and nonconvex nonlinear programs from a word problem.\n",
+    "2. Implement the same optimization model family in JuMP with continuous and integer decision variables.\n",
+    "3. Select appropriate LP, MILP, NLP, and MINLP solvers and interpret their reported solutions.\n",
+    "4. Explain how integrality and nonconvexity change the difficulty and reliability of optimization workflows.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Basic algebra, inequalities, objective functions, and familiarity with continuous and integer variables.  \n",
+    "**Prior notebooks:** None; this is the first Julia notebook in the sequence.  \n",
+    "**Accounts required:** None for the core examples; commercial solver sections require separate solver licenses.  \n",
+    "**Julia version:** Julia 1.10+ with the JuMP project environment used by this repository.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Colab Instructions\n",
     "\n",
     "If not in a Colab notebook, continue to the next section.\n",
@@ -1482,6 +1508,28 @@
    "metadata": {},
    "source": [
     "We are able to solve non-convex MINLP problems. However, the complexity of these problems leads to significant computational challenges that need to be tackled."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Built optimization models for a production-planning example across LP, ILP, convex INLP, and nonconvex INLP forms.\n",
+    "- Used JuMP to declare variables, objectives, and constraints, then called solvers suited to each model class.\n",
+    "- Compared how relaxations, integer restrictions, nonlinear constraints, and nonconvexity affect solution quality and solver behavior.\n",
+    "\n",
+    "**Learning objectives met:** You practiced formulating optimization models, implementing them in JuMP, choosing solver classes, and interpreting solver output across increasingly difficult model families.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 2: QUBO and Ising Models](2-QUBO.ipynb) to learn how constrained binary models can be rewritten as unconstrained quadratic objectives.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [JuMP documentation](https://jump.dev/JuMP.jl/stable/)\n",
+    "- [Ipopt.jl documentation](https://jump.dev/JuMP.jl/stable/packages/Ipopt/)\n",
+    "- [GLPK.jl documentation](https://jump.dev/JuMP.jl/stable/packages/GLPK/)\n"
    ]
   },
   {

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -36,6 +36,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Describe QUBO and Ising model forms and the role of linear, quadratic, and offset terms.\n",
+    "2. Convert constrained binary optimization problems into QUBO models using penalty terms.\n",
+    "3. Build and solve QUBO/Ising models with JuliaQUBO tooling and simulated annealing.\n",
+    "4. Validate sampled solutions and connect QUBO penalties to graph-coloring feasibility.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Binary variables, matrix notation, quadratic objectives, and basic graph terminology.  \n",
+    "**Prior notebooks:** Notebook 1 (MathProg) or equivalent experience with binary integer programming.  \n",
+    "**Accounts required:** None; all examples use local or Colab Julia packages.  \n",
+    "**Julia version:** Julia 1.10+ with the notebook project and JuliaQUBO packages instantiated.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "colab-install-instructions"
    },
@@ -2186,6 +2212,29 @@
     "        )\n",
     "    end,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Defined QUBO and Ising objectives and identified how coefficients encode binary optimization problems.\n",
+    "- Reformulated constrained binary problems with penalty terms so they can be sampled as unconstrained models.\n",
+    "- Used JuliaQUBO tooling and simulated annealing to solve models and inspect sampled energies.\n",
+    "- Modeled graph coloring directly from penalties and validated feasible color assignments.\n",
+    "\n",
+    "**Learning objectives met:** You practiced reading QUBO/Ising forms, building QUBO models, applying penalty reformulations, and checking sampled solutions against the original constraints.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 3: GAMA](3-GAMA.ipynb) to compare QUBO-style sampling with Graver-basis augmentation for structured integer programs.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl)\n",
+    "- [D-Wave Ocean concepts](https://docs.ocean.dwavesys.com/en/stable/concepts/index.html)\n",
+    "- [D-Wave map coloring example](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)\n"
    ]
   },
   {

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -37,6 +37,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Explain how Graver-basis directions can augment feasible integer solutions.\n",
+    "2. Run the GAMA workflow on a nonlinear integer programming instance using Julia tooling.\n",
+    "3. Compare complete and sampled Graver bases across objective improvement, iterations, and runtime.\n",
+    "4. Interpret the speed-quality tradeoff between exact augmentation data and smaller sampled direction sets.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Integer programming, feasible sets, nonlinear objective functions, and basic runtime comparisons.  \n",
+    "**Prior notebooks:** Notebook 2 (QUBO) and the binary/integer modeling ideas from Notebook 1.  \n",
+    "**Accounts required:** None; optional 4ti2 support can compute larger Graver bases.  \n",
+    "**Julia version:** Julia 1.10+ with the notebook project environment instantiated.\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -1227,6 +1253,29 @@
     "end\n",
     "\n",
     "plot_multiple_partial_augmentation(Y_feas, Y_mpaug)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Introduced Graver-basis augmentation as a structured approach for improving feasible integer solutions.\n",
+    "- Applied augmentation directions to multiple feasible starts for a nonlinear integer program.\n",
+    "- Compared complete and sampled direction sets using objective values, iteration counts, and runtime plots.\n",
+    "- Used the experiments to reason about when smaller direction subsets may be faster but less reliable.\n",
+    "\n",
+    "**Learning objectives met:** You practiced explaining Graver augmentation, running the GAMA workflow, comparing full and sampled bases, and interpreting the resulting runtime-quality tradeoff.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 4: D-Wave](4-DWave.ipynb) to see how QUBO models can be sent to quantum annealing hardware or a local fallback sampler.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Alghassi, Dridi, and Tayur, arXiv:1902.04215](https://arxiv.org/abs/1902.04215)\n",
+    "- [Alghassi, Dridi, and Tayur, arXiv:1907.10930](https://arxiv.org/abs/1907.10930)\n",
+    "- [4ti2 documentation](https://4ti2.github.io/)\n"
    ]
   },
   {

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -35,6 +35,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Prepare a QUBO model for submission through D-Wave-compatible Julia tooling.\n",
+    "2. Distinguish local simulated annealing from quantum annealing on D-Wave hardware.\n",
+    "3. Inspect QPU topology, embeddings, and chain-related sampling metadata when a solver is available.\n",
+    "4. Explain how annealing time, chain strength, and annealing schedules can affect sampling behavior.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** QUBO models, graph representations, and the penalty-model ideas from Notebook 2.  \n",
+    "**Prior notebooks:** Notebook 2 (QUBO); Notebook 3 is useful for comparing solver strategies.  \n",
+    "**Accounts required:** A D-Wave Leap account and token for QPU sections; local simulated annealing cells run without hardware access.  \n",
+    "**Julia version:** Julia 1.10+ with the notebook project and DWave.jl dependencies instantiated.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a name=\"installation\" id=\"installation\"></a>\n",
     "\n",
     "## Colab Instructions\n",
@@ -832,6 +858,29 @@
    "metadata": {},
    "source": [
     "Now we can play with the other parameters such as Annealing time, chain strenght, and annealing schedule to improve the performance of D-Wave's Quantum Annealing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Reused a QUBO model and sampled it with local simulated annealing and, when credentials are available, D-Wave quantum annealing.\n",
+    "- Checked D-Wave configuration and inspected solver topology before submitting work to the QPU.\n",
+    "- Examined embeddings, chain behavior, returned samples, and energy distributions.\n",
+    "- Identified annealing controls such as reads, chain strength, annealing time, and schedules for follow-up experiments.\n",
+    "\n",
+    "**Learning objectives met:** You practiced preparing QUBO models for D-Wave tooling, distinguishing local and QPU execution, inspecting embeddings, and connecting annealing parameters to solver behavior.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 5: Benchmarking](5-Benchmarking.ipynb) to compare solver performance with time-to-solution and performance-ratio metrics.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [DWave.jl](https://github.com/JuliaQUBO/DWave.jl)\n",
+    "- [D-Wave Ocean documentation](https://docs.ocean.dwavesys.com/)\n",
+    "- [D-Wave Leap documentation](https://docs.dwavesys.com/docs/latest/leap.html)\n"
    ]
   },
   {

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -37,6 +37,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Define solver, instance, schedule, and hyperparameter ensembles for benchmarking experiments.\n",
+    "2. Compute and interpret time-to-solution, success probability, and performance-ratio summaries.\n",
+    "3. Use bootstrap summaries to compare solver settings across repeated samples and instance ensembles.\n",
+    "4. Explain the difference between default, tuned, ensemble-selected, and virtual-best parameter choices.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** QUBO/Ising models, probability, medians, and confidence intervals.  \n",
+    "**Prior notebooks:** Notebooks 2-4, especially QUBO construction and simulated/quantum annealing outputs.  \n",
+    "**Accounts required:** None for the bundled cache; regenerating hardware data may require solver access.  \n",
+    "**Julia version:** Julia 1.10+ with the notebook project and benchmarking dependencies instantiated.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Colab Instructions\n",
     "\n",
     "If not in a Colab notebook, continue to the next section.\n",
@@ -26269,6 +26295,29 @@
    "metadata": {},
    "source": [
     "As you can see, there is a gap between the case with the best mean performance and the virtual best. This difference is arguably small, but you can imagine that with a larger number of parameters, this difference can become larger and larger, making the search of good parameters more worthy and complicated. We are actively working on such parameter setting strategies, and expect to make progress in this area (keep tuned!)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Treated a solver as a combination of hardware, algorithm, software, and hyperparameters to make comparisons reproducible.\n",
+    "- Loaded or generated benchmark samples and converted raw sampling results into success probabilities and time-to-solution metrics.\n",
+    "- Used bootstrap summaries and performance ratios to compare schedules, sweeps, default choices, and virtual-best behavior.\n",
+    "- Interpreted how tuning on one instance or ensemble can improve results while still leaving a gap to per-instance best choices.\n",
+    "\n",
+    "**Learning objectives met:** You practiced setting up benchmark ensembles, computing TTS and performance ratios, using bootstrap summaries, and interpreting scaling and tuning tradeoffs.\n",
+    "\n",
+    "**Next steps:** Proceed to [Python Notebook 6: QCi](../notebooks_py/6-QCi_python.ipynb) if you want to compare these benchmarking ideas with a QCi solver workflow.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Ronnow et al., Defining and detecting quantum speedup](https://doi.org/10.1126/science.1252319)\n",
+    "- [StatsBase.jl documentation](https://juliastats.org/StatsBase.jl/stable/)\n",
+    "- [D-Wave Ocean benchmarking resources](https://docs.ocean.dwavesys.com/)\n"
    ]
   }
  ],

--- a/notebooks_py/1-MathProg_python.ipynb
+++ b/notebooks_py/1-MathProg_python.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Formulate linear, integer, convex nonlinear, and nonconvex nonlinear programs from a word problem.\n",
+    "2. Implement the same optimization model family in Pyomo with continuous and integer decision variables.\n",
+    "3. Select appropriate LP, MILP, NLP, and MINLP solvers and interpret their reported solutions.\n",
+    "4. Explain how integrality and nonconvexity change the difficulty and reliability of optimization workflows.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Basic algebra, inequalities, objective functions, and familiarity with continuous and integer variables.  \n",
+    "**Prior notebooks:** None; this is the first Python notebook in the sequence.  \n",
+    "**Accounts required:** None for the core examples; commercial solver sections require separate solver licenses.  \n",
+    "**Python version:** Python 3.9+ with the Pyomo stack used by this repository.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction to Mathematical Programming\n",
     "### Modeling\n",
     "The solution of optimization problems requires the development of a mathematical model. Here we will model an example given in the lecture and see how an integer program can be solved practically. This example will use as modeling language **[Pyomo](http://www.pyomo.org/)**, an open-source Python package, which provides a flexible access to different solvers and a general modeling framework for linear and nonlinear integer programs.\n",
@@ -1454,6 +1480,28 @@
     "\n",
     "#### BARON Installation\n",
     "BARON is one of the most powerful MINLP solvers available today.  In order to install the software visit their **[Website](https://www.minlp.com/home)**, create an account, and obtain a license. Once you do that you can download and use the software."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Built optimization models for a production-planning example across LP, ILP, convex INLP, and nonconvex INLP forms.\n",
+    "- Used Pyomo to declare variables, objectives, and constraints, then called solvers suited to each model class.\n",
+    "- Compared how relaxations, integer restrictions, nonlinear constraints, and nonconvexity affect solution quality and solver behavior.\n",
+    "\n",
+    "**Learning objectives met:** You practiced formulating optimization models, implementing them in Pyomo, choosing solver classes, and interpreting solver output across increasingly difficult model families.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 2: QUBO and Ising Models](2-QUBO_python.ipynb) to learn how constrained binary models can be rewritten as unconstrained quadratic objectives.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Pyomo documentation](https://pyomo.readthedocs.io/)\n",
+    "- [Ipopt documentation](https://coin-or.github.io/Ipopt/)\n",
+    "- [GLPK documentation](https://www.gnu.org/software/glpk/)\n"
    ]
   }
  ],

--- a/notebooks_py/2-QUBO_python.ipynb
+++ b/notebooks_py/2-QUBO_python.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Describe QUBO and Ising model forms and the role of linear, quadratic, and offset terms.\n",
+    "2. Convert constrained binary optimization problems into QUBO models using penalty terms.\n",
+    "3. Build Binary Quadratic Models with `dimod` and solve them with simulated annealing.\n",
+    "4. Validate sampled solutions and connect QUBO penalties to graph-coloring feasibility.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Binary variables, matrix notation, quadratic objectives, and basic graph terminology.  \n",
+    "**Prior notebooks:** Notebook 1 (MathProg) or equivalent experience with binary integer programming.  \n",
+    "**Accounts required:** None; all examples use local Python packages.  \n",
+    "**Python version:** Python 3.9+ with the D-Wave Ocean packages used by this repository.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Quadratic Unconstrained Binary Optimization\n",
     "This notebook will explain the basics of the QUBO modeling. In order to implement the different QUBOs we will use D-Wave's packages **[dimod](https://github.com/dwavesystems/dimod)**, and then solve them using **[neal](https://github.com/dwavesystems/dwave-neal)**'s implementation of simulated annealing.\n",
     "For Groebner basis computations we will use **[Sympy](https://www.sympy.org/)** for symbolic computation in Python and **[Networkx](https://networkx.github.io/)** for network models/graphs."
@@ -2454,6 +2480,29 @@
    ],
    "source": [
     "plot_map(sample)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Defined QUBO and Ising objectives and identified how coefficients encode binary optimization problems.\n",
+    "- Reformulated constrained binary problems with penalty terms so they can be sampled as unconstrained BQMs.\n",
+    "- Used `dimod` and simulated annealing to sample candidate solutions and inspect their energies.\n",
+    "- Modeled graph coloring directly as a BQM and validated feasible color assignments without a CSP helper package.\n",
+    "\n",
+    "**Learning objectives met:** You practiced reading QUBO/Ising forms, building BQMs, applying penalty reformulations, and checking sampled solutions against the original constraints.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 3: GAMA](3-GAMA_python.ipynb) to compare QUBO-style sampling with Graver-basis augmentation for structured integer programs.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [D-Wave Ocean concepts](https://docs.ocean.dwavesys.com/en/stable/concepts/index.html)\n",
+    "- [dimod documentation](https://docs.ocean.dwavesys.com/projects/dimod/en/stable/)\n",
+    "- [D-Wave map coloring example](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)\n"
    ]
   }
  ],

--- a/notebooks_py/3-GAMA_python.ipynb
+++ b/notebooks_py/3-GAMA_python.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Explain how Graver-basis directions can augment feasible integer solutions.\n",
+    "2. Run the GAMA workflow on a nonlinear integer programming instance with bundled or computed Graver data.\n",
+    "3. Compare complete and sampled Graver bases across objective improvement, iterations, and runtime.\n",
+    "4. Interpret the speed-quality tradeoff between exact augmentation data and smaller sampled direction sets.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Integer programming, feasible sets, nonlinear objective functions, and basic runtime comparisons.  \n",
+    "**Prior notebooks:** Notebook 2 (QUBO) and the binary/integer modeling ideas from Notebook 1.  \n",
+    "**Accounts required:** None; optional `Py4ti2int32` or 4ti2 support can compute Graver bases instead of using bundled data.  \n",
+    "**Python version:** Python 3.9+ with NumPy, Matplotlib, and the repository's GAMA dependencies.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Environment and execution notes**\n",
     "\n",
     "For local execution from the repository root, run `uv sync --group qubo` before launching Jupyter so the Python scientific stack used below is available. If `Py4ti2int32` is installed, the notebook computes the Graver basis directly; otherwise it falls back to the bundled `graver.npy` file so the rest of the workflow still runs.\n",
@@ -1340,6 +1366,29 @@
     "ax1.set_title('Iterations across Graver-basis sample sizes')\n",
     "plt.xticks(rotation=45)\n",
     "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Introduced Graver-basis augmentation as a structured approach for improving feasible integer solutions.\n",
+    "- Loaded or computed augmentation directions and applied them to multiple feasible starts for a nonlinear integer program.\n",
+    "- Compared complete and sampled direction sets using objective values, iteration counts, and runtime plots.\n",
+    "- Used the experiments to reason about when smaller direction subsets may be faster but less reliable.\n",
+    "\n",
+    "**Learning objectives met:** You practiced explaining Graver augmentation, running the GAMA workflow, comparing full and sampled bases, and interpreting the resulting runtime-quality tradeoff.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 4: D-Wave](4-DWAVE_python.ipynb) to see how QUBO models can be sent to quantum annealing hardware or a local fallback sampler.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Alghassi, Dridi, and Tayur, arXiv:1902.04215](https://arxiv.org/abs/1902.04215)\n",
+    "- [Alghassi, Dridi, and Tayur, arXiv:1907.10930](https://arxiv.org/abs/1907.10930)\n",
+    "- [4ti2 documentation](https://4ti2.github.io/)\n"
    ]
   },
   {

--- a/notebooks_py/4-DWAVE_python.ipynb
+++ b/notebooks_py/4-DWAVE_python.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Prepare a QUBO/BQM for submission through D-Wave Ocean tools.\n",
+    "2. Distinguish local simulated annealing from quantum annealing on D-Wave hardware.\n",
+    "3. Inspect QPU topology, embeddings, and chain-related sampling metadata when a solver is available.\n",
+    "4. Explain how annealing time, chain strength, and annealing schedules can affect sampling behavior.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** QUBO models, graph representations, and the penalty-model ideas from Notebook 2.  \n",
+    "**Prior notebooks:** Notebook 2 (QUBO); Notebook 3 is useful for comparing solver strategies.  \n",
+    "**Accounts required:** A D-Wave Leap account and `DWAVE_API_TOKEN` for QPU sections; local fallback cells run without a token.  \n",
+    "**Python version:** Python 3.9+ with D-Wave Ocean packages available outside the locked portable environment.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Quantum Annealing via D-Wave\n",
     "This notebook will give the first interaction with D-Wave's Quantum Annealer. It will use the QUBO modeling problem introduced earlier and will define it using D-Wave's package **[dimod](https://github.com/dwavesystems/dimod)**, and then solve them using **[neal](https://github.com/dwavesystems/dwave-neal)**'s implementation of simulated annealing classicaly and D-Wave system package to use Quantum Annealing.\n",
     "We will also leverage the use of **[Networkx](https://networkx.github.io/)** for network models/graphs."
@@ -732,6 +758,29 @@
    "metadata": {},
    "source": [
     "Now we can play with the other parameters such as Annealing time, chain strength, and annealing schedule to improve the performance of D-Wave's Quantum Annealing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Reused a QUBO/BQM model and sampled it with local simulated annealing and, when credentials are available, D-Wave quantum annealing.\n",
+    "- Checked D-Wave configuration and guarded QPU access so local runs can fall back gracefully.\n",
+    "- Inspected solver topology, embeddings, returned sample metadata, and energy distributions.\n",
+    "- Identified annealing controls such as reads, chain strength, annealing time, and schedules for follow-up experiments.\n",
+    "\n",
+    "**Learning objectives met:** You practiced preparing BQMs for Ocean samplers, distinguishing local and QPU execution, inspecting embeddings, and connecting annealing parameters to solver behavior.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 5: Benchmarking](5-Benchmarking_python.ipynb) to compare solver performance with time-to-solution and performance-ratio metrics.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [D-Wave Ocean documentation](https://docs.ocean.dwavesys.com/)\n",
+    "- [dwave-system documentation](https://docs.ocean.dwavesys.com/projects/system/en/stable/)\n",
+    "- [D-Wave Leap documentation](https://docs.dwavesys.com/docs/latest/leap.html)\n"
    ]
   }
  ],

--- a/notebooks_py/5-Benchmarking_python.ipynb
+++ b/notebooks_py/5-Benchmarking_python.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Define solver, instance, schedule, and hyperparameter ensembles for benchmarking experiments.\n",
+    "2. Compute and interpret time-to-solution, success probability, and performance-ratio summaries.\n",
+    "3. Use bootstrap summaries to compare solver settings across repeated samples and instance ensembles.\n",
+    "4. Explain the difference between default, tuned, ensemble-selected, and virtual-best parameter choices.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** QUBO/Ising models, probability, medians, and confidence intervals.  \n",
+    "**Prior notebooks:** Notebooks 2-4, especially QUBO construction and simulated/quantum annealing outputs.  \n",
+    "**Accounts required:** None for the bundled cache; regenerating hardware data may require solver access.  \n",
+    "**Python version:** Python 3.9+ with the repository's benchmarking dependencies.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# About this Notebook\n",
     "\n",
     "With the new availability of unconventional hardware, novel algorithms, and increasingly optimized software to address optimization problems; the first question that arises is, which one is better?\n",
@@ -2580,6 +2606,29 @@
    "metadata": {},
    "source": [
     "As you can see, there is a gap between the case with the best mean performance and the virtual best. This difference is arguably small, but you can imagine that with a larger number of parameters, this difference can become larger and larger, making the search of good parameters more worthy and complicated. We are actively working on such parameter setting strategies, and expect to make progress in this area (keep tuned!)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Treated a solver as a combination of hardware, algorithm, software, and hyperparameters to make comparisons reproducible.\n",
+    "- Loaded or generated benchmark samples and converted raw sampling results into success probabilities and time-to-solution metrics.\n",
+    "- Used bootstrap summaries and performance ratios to compare schedules, sweeps, default choices, and virtual-best behavior.\n",
+    "- Interpreted how tuning on one instance or ensemble can improve results while still leaving a gap to per-instance best choices.\n",
+    "\n",
+    "**Learning objectives met:** You practiced setting up benchmark ensembles, computing TTS and performance ratios, using bootstrap summaries, and interpreting scaling and tuning tradeoffs.\n",
+    "\n",
+    "**Next steps:** Proceed to [Notebook 6: QCi](6-QCi_python.ipynb) to see another quantum-inspired solver workflow and compare its modeling interface with QUBO/BQM approaches.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Ronnow et al., Defining and detecting quantum speedup](https://doi.org/10.1126/science.1252319)\n",
+    "- [SciPy bootstrap documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html)\n",
+    "- [D-Wave Ocean benchmarking resources](https://docs.ocean.dwavesys.com/)\n"
    ]
   }
  ],

--- a/notebooks_py/6-QCi_python.ipynb
+++ b/notebooks_py/6-QCi_python.ipynb
@@ -33,6 +33,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. Describe how QCi's Dirac solvers represent constrained optimization problems.\n",
+    "2. Formulate a constrained quadratic or polynomial model with objective coefficients and linear constraints.\n",
+    "3. Submit a model to Dirac-3 solvers when credentials are available and decode returned solutions.\n",
+    "4. Compare manual QUBO penalty construction with `ConstrainedPolynomialModel` handling of constraints and offsets.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Mathematical background:** Binary optimization, QUBO penalties, matrix multiplication, and linear equality constraints.  \n",
+    "**Prior notebooks:** Notebook 2 (QUBO) and Notebook 5 (Benchmarking) for solver comparison context.  \n",
+    "**Accounts required:** QCi account credentials and an API token for cloud solver execution.  \n",
+    "**Python version:** Python 3.9+ with the QCi Python stack used by this notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Entropy Computing via QCi\n",
     "This notebook provides an introduction to solving constrained optimization problems using **Quantum Computing Inc.'s (QCI) Entropy Quantum Computer**.\n",
     "We will define a **Constrained Quadratic Model** by setting up an objective function and a series of linear constraints. The notebook demonstrates how to:\n",
@@ -1344,6 +1370,29 @@
     "\n",
     "print(f\"Best Solution: {best_solution}\")\n",
     "print(f\"Best Objective Value: {best_objective_value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Introduced QCi's entropy-computing workflow and the Dirac-3 solver interface for constrained optimization.\n",
+    "- Built constrained quadratic and polynomial model representations from linear objective and constraint data.\n",
+    "- Submitted models to QCi solvers when credentials are available and decoded the returned solution vectors and energies.\n",
+    "- Compared manual QUBO offset handling with the constrained polynomial model abstraction.\n",
+    "\n",
+    "**Learning objectives met:** You practiced describing the Dirac modeling workflow, constructing constrained models, decoding solver responses, and comparing explicit QUBO penalties with higher-level constraint handling.\n",
+    "\n",
+    "**Next steps:** This is the final Python notebook in the current sequence; use the benchmarking notebook to design fair comparisons when applying QCi models to your own optimization instances.\n",
+    "\n",
+    "**Further reading:**\n",
+    "- [Nguyen et al., Entropy Computing, arXiv:2407.04512](https://arxiv.org/abs/2407.04512)\n",
+    "- [QCi documentation](https://docs.quantumcomputinginc.com/)\n",
+    "- [QCi Python client package](https://pypi.org/project/qci-client/)\n"
    ]
   },
   {

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import tempfile
 import unittest
 import zipfile
@@ -43,6 +44,7 @@ NOTEBOOK_DIRS = (
     REPO_ROOT / "notebooks_jl",
     REPO_ROOT / "notebooks_py",
 )
+NOTEBOOK_REFERENCE_HEADING = re.compile(r"^#+\s+references\b", re.IGNORECASE)
 GAMA_DATA_FILES = (
     REPO_ROOT / "notebooks_data" / "3-GAMA_example4_coefficients.csv",
     REPO_ROOT / "notebooks_data" / "3-GAMA_example4_feasible_starts.csv",
@@ -84,8 +86,24 @@ def notebook_cell_sources(path: Path) -> list[str]:
     return ["".join(cell.get("source", [])) for cell in notebook["cells"]]
 
 
+def notebook_cells(path: Path) -> list[dict]:
+    notebook = json.loads(path.read_text())
+    return notebook["cells"]
+
+
 def notebook_paths() -> list[Path]:
     return sorted(path for directory in NOTEBOOK_DIRS for path in directory.glob("*.ipynb"))
+
+
+def notebook_first_heading(cell: dict) -> str:
+    source = "".join(cell.get("source", []))
+
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+
+    return ""
 
 
 class NotebookSourceSafetyTests(unittest.TestCase):
@@ -106,6 +124,57 @@ class NotebookSourceSafetyTests(unittest.TestCase):
 
         self.assertIn("JuMP.backend(color_model).optimizer", source)
         self.assertNotIn("solution(backend(color_model)", source)
+
+
+class NotebookPedagogyCellTests(unittest.TestCase):
+    def test_learning_objectives_and_prerequisites_are_top_cells(self) -> None:
+        for path in notebook_paths():
+            with self.subTest(notebook=path.relative_to(REPO_ROOT).as_posix()):
+                cells = notebook_cells(path)
+
+                self.assertEqual("## Learning objectives", notebook_first_heading(cells[1]))
+                self.assertEqual("## Prerequisites", notebook_first_heading(cells[2]))
+                self.assertIn(
+                    "By the end of this notebook you will be able to:",
+                    "".join(cells[1].get("source", [])),
+                )
+                self.assertIn(
+                    "**Prior notebooks:**",
+                    "".join(cells[2].get("source", [])),
+                )
+
+    def test_summaries_close_learning_content(self) -> None:
+        for path in notebook_paths():
+            with self.subTest(notebook=path.relative_to(REPO_ROOT).as_posix()):
+                cells = notebook_cells(path)
+                summary_indices = [
+                    index
+                    for index, cell in enumerate(cells)
+                    if notebook_first_heading(cell) in {"## Summary", "## Conclusion"}
+                ]
+                reference_indices = [
+                    index
+                    for index, cell in enumerate(cells)
+                    if NOTEBOOK_REFERENCE_HEADING.match(notebook_first_heading(cell))
+                ]
+
+                self.assertEqual(1, len(summary_indices))
+                summary_index = summary_indices[0]
+                summary_source = "".join(cells[summary_index].get("source", []))
+
+                self.assertIn("**Learning objectives met:**", summary_source)
+                self.assertIn("**Next steps:**", summary_source)
+                self.assertIn("**Further reading:**", summary_source)
+                further_reading = summary_source.split("**Further reading:**", 1)[1]
+                further_reading_items = [
+                    line for line in further_reading.splitlines() if line.startswith("- ")
+                ]
+                self.assertGreaterEqual(len(further_reading_items), 2)
+
+                if reference_indices:
+                    self.assertEqual(reference_indices[0] - 1, summary_index)
+                else:
+                    self.assertEqual(len(cells) - 1, summary_index)
 
 
 class PythonPlotSamplesNotebookTests(unittest.TestCase):
@@ -829,7 +898,7 @@ class JuliaColabSetupTests(unittest.TestCase):
                     i for i, source in enumerate(cells) if "Pkg.activate(@__DIR__)" in source
                 ]
 
-                self.assertEqual([2], install_indexes)
+                self.assertEqual(1, len(install_indexes))
                 self.assertTrue(activate_indexes)
                 self.assertLess(install_indexes[0], min(activate_indexes))
                 self.assertIn("precompiled QUBONotebooks sysimage", cells[install_indexes[0] - 1])


### PR DESCRIPTION
Closes #62
Closes #64

## Summary

- Adds notebook-specific `## Learning objectives` and `## Prerequisites` cells immediately after the title cell in all 11 notebooks listed in #64.
- Adds `## Summary` cells with key concepts, learning-objective coverage, next steps, and further reading.
- Places summaries immediately before existing References sections, or as the final cell for notebooks without a References section.
- Adds regression coverage for the new pedagogical cells and updates the Julia Colab setup test to assert installer-before-activation ordering semantically after the new top cells.

## Notes

- Issue #64 says "10 notebooks" in prose but lists 11 concrete notebook files; this PR updates all 11 listed files.
- Notebook outputs were not re-executed because the change is markdown-only and does not alter runnable code cells.

## Validation

- `python -m unittest tests.test_verify_notebooks.NotebookPedagogyCellTests`
- `make test-python`
- `make test`
- `make test-julia`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `2316c3c13c3eecc13e0dc94b02330e28ea73ddd8`
- Stacked status: unstacked; no prerequisite PRs
