### PR TITLE
[codex] Align paired notebook checkpoint outputs

### DIFF
--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -1803,7 +1803,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(minimizer = (0.0, 0.0), maximizer = (4.0, 0.0))\n"
+      "minimizer = (0.0, 0.0); maximizer = (4.0, 0.0)\n"
      ]
     }
    ],
@@ -1813,7 +1813,9 @@
     "candidate_points = [(0.0, 0.0), (4.0, 0.0), (0.0, 6.0), (2.0, 3.0)]\n",
     "objective(point) = 5.5 * point[1] + 2.1 * point[2]\n",
     "objective_pairs = sort([(point, objective(point)) for point in candidate_points]; by = item -> item[2])\n",
-    "println((minimizer = objective_pairs[1][1], maximizer = objective_pairs[end][1]))"
+    "minimizer = objective_pairs[1][1]\n",
+    "maximizer = objective_pairs[end][1]\n",
+    "println(\"minimizer = $(minimizer); maximizer = $(maximizer)\")\n"
    ]
   },
   {
@@ -1860,7 +1862,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(continuous = (2.4, 1.6), best_integer = (3, 2))\n"
+      "continuous = (2.4, 1.6); best_integer = (3, 2)\n"
      ]
     }
    ],
@@ -1870,8 +1872,8 @@
     "continuous_solution = (2.4, 1.6)\n",
     "integer_candidates = [(2, 1), (2, 2), (3, 1), (3, 2)]\n",
     "objective(point) = 5.5 * point[1] + 2.1 * point[2]\n",
-    "best_integer = sort([(point, objective(point)) for point in integer_candidates]; by = item -> item[2])[end]\n",
-    "println((continuous = continuous_solution, best_integer = best_integer[1]))"
+    "best_integer = sort(integer_candidates; by = objective, rev = true)[1]\n",
+    "println(\"continuous = $(continuous_solution); best_integer = $(best_integer)\")\n"
    ]
   },
   {
@@ -1918,7 +1920,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(remaining_feasible_points = [(0, 0), (4, 0)],)\n"
+      "remaining_feasible_points = [(0, 0), (4, 0)]\n"
      ]
     }
    ],
@@ -1928,7 +1930,7 @@
     "candidate_points = [(0, 0), (4, 0), (0, 6), (2, 3), (3, 2)]\n",
     "satisfies_new_constraint(point) = point[1] + point[2] <= 4\n",
     "remaining_points = filter(satisfies_new_constraint, candidate_points)\n",
-    "println((remaining_feasible_points = remaining_points,))"
+    "println(\"remaining_feasible_points = $(remaining_points)\")\n"
    ]
   },
   {

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -2740,7 +2740,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(best_assignment = (1, 0, 0), energy = 0.0, feasible = true)\n"
+      "best_assignment = (1, 0, 0); energy = 0.0; feasible = true\n"
      ]
     }
    ],
@@ -2761,8 +2761,12 @@
     "    end\n",
     "    return total\n",
     "end\n",
-    "best = sort([(Tuple(bits), energy(bits)) for bits in assignments]; by = item -> item[2])[1]\n",
-    "println((best_assignment = best[1], energy = best[2], feasible = sum(collect(best[1])) == 1))"
+    "best = sort(\n",
+    "    [(Tuple(bits), energy(bits)) for bits in assignments];\n",
+    "    by = item -> (item[2], -item[1][1], -item[1][2], -item[1][3]),\n",
+    ")[1]\n",
+    "feasible = sum(collect(best[1])) == 1\n",
+    "println(\"best_assignment = $(best[1]); energy = $(best[2]); feasible = $(feasible)\")\n"
    ]
   },
   {
@@ -2809,7 +2813,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(rho = 0.25, best_assignment = (0, 0, 0), energy = 0.5, feasible = false)\n"
+      "rho = 0.25; best_assignment = (0, 0, 0); energy = 0.5; feasible = false\n"
      ]
     }
    ],
@@ -2827,7 +2831,7 @@
     "end\n",
     "rho_value = 0.25\n",
     "best = sort([(Tuple(bits), penalized_energy(bits, rho_value), A_small * collect(bits) == b_small) for bits in assignments]; by = item -> item[2])[1]\n",
-    "println((rho = rho_value, best_assignment = best[1], energy = best[2], feasible = best[3]))"
+    "println(\"rho = $(rho_value); best_assignment = $(best[1]); energy = $(best[2]); feasible = $(best[3])\")\n"
    ]
   },
   {
@@ -2874,7 +2878,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(one_hot_groups = [[\"x_1_red\", \"x_1_green\", \"x_1_blue\"], [\"x_2_red\", \"x_2_green\", \"x_2_blue\"], [\"x_3_red\", \"x_3_green\", \"x_3_blue\"]], edge_conflicts = [(\"x_1_red\", \"x_2_red\"), (\"x_1_green\", \"x_2_green\"), (\"x_1_blue\", \"x_2_blue\"), (\"x_2_red\", \"x_3_red\"), (\"x_2_green\", \"x_3_green\"), (\"x_2_blue\", \"x_3_blue\")])\n"
+      "one_hot_groups = x_1_red,x_1_green,x_1_blue | x_2_red,x_2_green,x_2_blue | x_3_red,x_3_green,x_3_blue; edge_conflicts = x_1_red-x_2_red | x_1_green-x_2_green | x_1_blue-x_2_blue | x_2_red-x_3_red | x_2_green-x_3_green | x_2_blue-x_3_blue\n"
      ]
     }
    ],
@@ -2887,7 +2891,11 @@
     "variables = Dict((node, color) => \"x_$(node)_$(color)\" for node in nodes for color in colors)\n",
     "one_hot_groups = [[variables[(node, color)] for color in colors] for node in nodes]\n",
     "edge_conflicts = [(variables[(u, color)], variables[(v, color)]) for (u, v) in edges for color in colors]\n",
-    "println((one_hot_groups = one_hot_groups, edge_conflicts = edge_conflicts))"
+    "format_group(group) = join(group, \",\")\n",
+    "format_conflict(conflict) = \"$(conflict[1])-$(conflict[2])\"\n",
+    "formatted_groups = join(format_group.(one_hot_groups), \" | \")\n",
+    "formatted_conflicts = join(format_conflict.(edge_conflicts), \" | \")\n",
+    "println(\"one_hot_groups = $(formatted_groups); edge_conflicts = $(formatted_conflicts)\")\n"
    ]
   },
   {

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -1506,7 +1506,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(start = (2, 1), path = [(2, 1), (1, 2)], objectives = [9, 6])\n"
+      "start = (2, 1); path = [(2, 1), (1, 2)]; objectives = [9, 6]\n"
      ]
     }
    ],
@@ -1519,12 +1519,13 @@
     "moves = [(-1, 1), (1, -1)]\n",
     "path = [start]\n",
     "for move in moves\n",
-    "    candidate = (path[end][1] + move[1], path[end][2] + move[2])\n",
+    "    candidate = path[end] .+ move\n",
     "    if candidate in feasible_starts && objective(candidate) < objective(path[end])\n",
     "        push!(path, candidate)\n",
     "    end\n",
     "end\n",
-    "println((start = start, path = path, objectives = objective.(path)))"
+    "objectives = objective.(path)\n",
+    "println(\"start = $(start); path = $(path); objectives = $(objectives)\")\n"
    ]
   },
   {
@@ -1571,7 +1572,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(first_improving = (5.0, \"move_a\"), best_improving = (2.0, \"move_b\"))\n"
+      "first_improving = (5.0, \"move_a\"); best_improving = (2.0, \"move_b\")\n"
      ]
     }
    ],
@@ -1580,8 +1581,9 @@
     "# Compare first-improving and best-improving choices on the same candidate list.\n",
     "candidates = [(5.0, \"move_a\"), (2.0, \"move_b\"), (3.0, \"move_c\")]\n",
     "first_improving = first(filter(candidate -> candidate[1] < 6.0, candidates))\n",
-    "best_improving = sort(candidates; by = item -> item[1])[1]\n",
-    "println((first_improving = first_improving, best_improving = best_improving))"
+    "best_improving = sort(candidates; by = first)[1]\n",
+    "format_candidate(candidate) = string(\"(\", candidate[1], \", \\\"\", candidate[2], \"\\\")\")\n",
+    "println(\"first_improving = $(format_candidate(first_improving)); best_improving = $(format_candidate(best_improving))\")\n"
    ]
   },
   {
@@ -1628,7 +1630,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(old_gains = [3.0, -3.0, 1.0], new_gains = [-3.0, 3.0, 4.0])\n"
+      "old_gains = [3.0, -3.0, 1.0]; new_gains = [-3.0, 3.0, 4.0]\n"
      ]
     }
    ],
@@ -1639,7 +1641,9 @@
     "old_c = (4.0, 1.0)\n",
     "new_c = (1.0, 4.0)\n",
     "gains(coefficients) = [sum(coefficients[i] * move[i] for i in eachindex(move)) for move in moves]\n",
-    "println((old_gains = gains(old_c), new_gains = gains(new_c)))"
+    "old_gains = gains(old_c)\n",
+    "new_gains = gains(new_c)\n",
+    "println(\"old_gains = $(old_gains); new_gains = $(new_gains)\")\n"
    ]
   },
   {

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -928,8 +928,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(rho = 0.25, best = ((0, 0), 0.25), feasible = false)\n",
-      "(rho = 4.0, best = ((1, 0), 1.0), feasible = true)\n"
+      "rho = 0.25; best = ((0, 0), 0.25); feasible = false\n",
+      "rho = 4.0; best = ((1, 0), 1.0); feasible = true\n"
      ]
     }
    ],
@@ -944,10 +944,11 @@
     "    objective + rho_value * violation^2\n",
     "end\n",
     "for rho_value in [0.25, 4.0]\n",
-    "    local best\n",
+    "    local best, feasible\n",
     "    best = sort([(Tuple(bits), penalty_energy(bits, rho_value)) for bits in assignments]; by = item -> item[2])[1]\n",
-    "    println((rho = rho_value, best = best, feasible = sum(collect(best[1])) == 1))\n",
-    "end"
+    "    feasible = sum(collect(best[1])) == 1\n",
+    "    println(\"rho = $(rho_value); best = $(best); feasible = $(feasible)\")\n",
+    "end\n"
    ]
   },
   {
@@ -994,7 +995,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dict(500 => -1.05, 1000 => -1.1, 100 => -1.0)\n"
+      "best_energy_by_reads = {100: -1.0, 500: -1.05, 1000: -1.1}\n"
      ]
     }
    ],
@@ -1003,7 +1004,8 @@
     "# Sweep read counts with a deterministic stand-in for best-energy summaries.\n",
     "read_counts = [100, 500, 1000]\n",
     "best_energy_by_reads = Dict(reads => min(-1.0, -1.0 - 0.05 * (index - 1)) for (index, reads) in enumerate(read_counts))\n",
-    "println(best_energy_by_reads)"
+    "formatted_results = join([\"$(reads): $(best_energy_by_reads[reads])\" for reads in read_counts], \", \")\n",
+    "println(\"best_energy_by_reads = {$(formatted_results)}\")\n"
    ]
   },
   {
@@ -1060,10 +1062,11 @@
     "if @isdefined(sampleset) && haskey(QUBOTools.metadata(sampleset), \"embedding\")\n",
     "    embedding = QUBOTools.metadata(sampleset)[\"embedding\"]\n",
     "    chain_lengths = Dict(variable => length(chain) for (variable, chain) in embedding)\n",
-    "    println((chain_lengths = chain_lengths,))\n",
+    "    formatted_lengths = join([\"$(variable): $(chain_lengths[variable])\" for variable in sort(collect(keys(chain_lengths)))], \", \")\n",
+    "    println(\"chain_lengths = {$(formatted_lengths)}\")\n",
     "else\n",
     "    println(\"QPU embedding metadata is unavailable; use the local fallback result above.\")\n",
-    "end"
+    "end\n"
    ]
   },
   {

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -4346,7 +4346,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[\"new_sampler\" => Dict(\"time\" => 2.1, \"best_energy\" => -12.6), \"baseline_sa\" => Dict(\"time\" => 1.8, \"best_energy\" => -12.4)]\n"
+      "solver_results = new_sampler: best_energy=-12.6, time=2.1; baseline_sa: best_energy=-12.4, time=1.8\n"
      ]
     }
    ],
@@ -4357,7 +4357,16 @@
     "    \"baseline_sa\" => Dict(\"best_energy\" => -12.4, \"time\" => 1.8),\n",
     "    \"new_sampler\" => Dict(\"best_energy\" => -12.6, \"time\" => 2.1),\n",
     ")\n",
-    "println(sort(collect(solver_results); by = item -> item[2][\"best_energy\"]))"
+    "sorted_results = sort(collect(solver_results); by = item -> item[2][\"best_energy\"])\n",
+    "formatted_results = [\n",
+    "    begin\n",
+    "        best_energy = metrics[\"best_energy\"]\n",
+    "        time_value = metrics[\"time\"]\n",
+    "        \"$(name): best_energy=$(best_energy), time=$(time_value)\"\n",
+    "    end\n",
+    "    for (name, metrics) in sorted_results\n",
+    "]\n",
+    "println(\"solver_results = $(join(formatted_results, \"; \"))\")\n"
    ]
   },
   {
@@ -4404,7 +4413,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(target_confidence = 0.99, tts_reads = 2900)\n"
+      "target_confidence = 0.99; tts_reads = 2900\n"
      ]
     }
    ],
@@ -4415,7 +4424,7 @@
     "target_confidence = 0.99\n",
     "reads_per_run = 100\n",
     "tts_reads = ceil(Int, log(1 - target_confidence) / log(1 - success_probability)) * reads_per_run\n",
-    "println((target_confidence = target_confidence, tts_reads = tts_reads))"
+    "println(\"target_confidence = $(target_confidence); tts_reads = $(tts_reads)\")\n"
    ]
   },
   {
@@ -4462,7 +4471,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(performance_ratio = 0.75,)\n"
+      "performance_ratio = 0.75\n"
      ]
     }
    ],
@@ -4473,7 +4482,7 @@
     "random_energy = -3.0\n",
     "observed_energy = -12.0\n",
     "performance_ratio = (observed_energy - random_energy) / (best_energy - random_energy)\n",
-    "println((performance_ratio = performance_ratio,))"
+    "println(\"performance_ratio = $(performance_ratio)\")\n"
    ]
   },
   {

--- a/notebooks_py/1-MathProg_python.ipynb
+++ b/notebooks_py/1-MathProg_python.ipynb
@@ -1596,7 +1596,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'minimizer': (0.0, 0.0), 'maximizer': (4.0, 0.0)}\n"
+      "minimizer = (0.0, 0.0); maximizer = (4.0, 0.0)\n"
      ]
     }
    ],
@@ -1610,7 +1610,7 @@
     "}\n",
     "minimizer = min(objective_values, key=objective_values.get)\n",
     "maximizer = max(objective_values, key=objective_values.get)\n",
-    "print({\"minimizer\": minimizer, \"maximizer\": maximizer})"
+    "print(f\"minimizer = {minimizer}; maximizer = {maximizer}\")\n"
    ]
   },
   {
@@ -1657,7 +1657,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'continuous': (2.4, 1.6), 'best_integer': (3, 2)}\n"
+      "continuous = (2.4, 1.6); best_integer = (3, 2)\n"
      ]
     }
    ],
@@ -1668,7 +1668,7 @@
     "integer_candidates = [(2, 1), (2, 2), (3, 1), (3, 2)]\n",
     "objective = lambda point: 5.5 * point[0] + 2.1 * point[1]\n",
     "best_integer = max(integer_candidates, key=objective)\n",
-    "print({\"continuous\": continuous_solution, \"best_integer\": best_integer})"
+    "print(f\"continuous = {continuous_solution}; best_integer = {best_integer}\")\n"
    ]
   },
   {
@@ -1715,7 +1715,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'remaining_feasible_points': [(0, 0), (4, 0)]}\n"
+      "remaining_feasible_points = [(0, 0), (4, 0)]\n"
      ]
     }
    ],
@@ -1728,7 +1728,7 @@
     "    return x1 + x2 <= 4\n",
     "\n",
     "remaining_points = [point for point in candidate_points if satisfies_new_constraint(point)]\n",
-    "print({\"remaining_feasible_points\": remaining_points})"
+    "print(f\"remaining_feasible_points = {remaining_points}\")\n"
    ]
   },
   {

--- a/notebooks_py/2-QUBO_python.ipynb
+++ b/notebooks_py/2-QUBO_python.ipynb
@@ -2597,7 +2597,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'best_assignment': (0, 0, 1), 'energy': 0.0, 'feasible': True}\n"
+      "best_assignment = (1, 0, 0); energy = 0.0; feasible = true\n"
      ]
     }
    ],
@@ -2618,9 +2618,10 @@
     "\n",
     "best = min(\n",
     "    ((bits, energy(bits)) for bits in itertools.product([0, 1], repeat=3)),\n",
-    "    key=lambda item: item[1],\n",
+    "    key=lambda item: (item[1], -item[0][0], -item[0][1], -item[0][2]),\n",
     ")\n",
-    "print({\"best_assignment\": best[0], \"energy\": best[1], \"feasible\": sum(best[0]) == 1})"
+    "feasible = sum(best[0]) == 1\n",
+    "print(f\"best_assignment = {best[0]}; energy = {best[1]}; feasible = {str(feasible).lower()}\")\n"
    ]
   },
   {
@@ -2667,7 +2668,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'rho': 0.25, 'best_assignment': (0, 0, 0), 'energy': 0.5, 'feasible': False}\n"
+      "rho = 0.25; best_assignment = (0, 0, 0); energy = 0.5; feasible = false\n"
      ]
     }
    ],
@@ -2693,7 +2694,7 @@
     "    ),\n",
     "    key=lambda item: item[1],\n",
     ")\n",
-    "print({\"rho\": rho_value, \"best_assignment\": best[0], \"energy\": best[1], \"feasible\": best[2]})"
+    "print(f\"rho = {rho_value}; best_assignment = {best[0]}; energy = {best[1]}; feasible = {str(best[2]).lower()}\")\n"
    ]
   },
   {
@@ -2740,15 +2741,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'one_hot_groups': [['x_0_red', 'x_0_green', 'x_0_blue'], ['x_1_red', 'x_1_green', 'x_1_blue'], ['x_2_red', 'x_2_green', 'x_2_blue']], 'edge_conflicts': [('x_0_red', 'x_1_red'), ('x_0_green', 'x_1_green'), ('x_0_blue', 'x_1_blue'), ('x_1_red', 'x_2_red'), ('x_1_green', 'x_2_green'), ('x_1_blue', 'x_2_blue')]}\n"
+      "one_hot_groups = x_1_red,x_1_green,x_1_blue | x_2_red,x_2_green,x_2_blue | x_3_red,x_3_green,x_3_blue; edge_conflicts = x_1_red-x_2_red | x_1_green-x_2_green | x_1_blue-x_2_blue | x_2_red-x_3_red | x_2_green-x_3_green | x_2_blue-x_3_blue\n"
      ]
     }
    ],
    "source": [
     "# SOLUTION (hidden in workshop version):\n",
     "# Create variables and constraints for a three-color graph-coloring BQM sketch.\n",
-    "nodes = [0, 1, 2]\n",
-    "edges = [(0, 1), (1, 2)]\n",
+    "nodes = [1, 2, 3]\n",
+    "edges = [(1, 2), (2, 3)]\n",
     "colors = [\"red\", \"green\", \"blue\"]\n",
     "variables = {(node, color): f\"x_{node}_{color}\" for node in nodes for color in colors}\n",
     "one_hot_groups = [[variables[node, color] for color in colors] for node in nodes]\n",
@@ -2757,7 +2758,14 @@
     "    for u, v in edges\n",
     "    for color in colors\n",
     "]\n",
-    "print({\"one_hot_groups\": one_hot_groups, \"edge_conflicts\": edge_conflicts})"
+    "format_group = lambda group: \",\".join(group)\n",
+    "format_conflict = lambda conflict: f\"{conflict[0]}-{conflict[1]}\"\n",
+    "print(\n",
+    "    \"one_hot_groups = \"\n",
+    "    + \" | \".join(format_group(group) for group in one_hot_groups)\n",
+    "    + \"; edge_conflicts = \"\n",
+    "    + \" | \".join(format_conflict(conflict) for conflict in edge_conflicts)\n",
+    ")\n"
    ]
   },
   {

--- a/notebooks_py/3-GAMA_python.ipynb
+++ b/notebooks_py/3-GAMA_python.ipynb
@@ -1457,7 +1457,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'start': (2, 1), 'path': [(2, 1), (1, 2)], 'objectives': [9, 6]}\n"
+      "start = (2, 1); path = [(2, 1), (1, 2)]; objectives = [9, 6]\n"
      ]
     }
    ],
@@ -1470,10 +1470,11 @@
     "moves = [(-1, 1), (1, -1)]\n",
     "path = [start]\n",
     "for move in moves:\n",
-    "    candidate = (path[-1][0] + move[0], path[-1][1] + move[1])\n",
+    "    candidate = tuple(a + b for a, b in zip(path[-1], move))\n",
     "    if candidate in feasible_starts and objective(candidate) < objective(path[-1]):\n",
     "        path.append(candidate)\n",
-    "print({\"start\": start, \"path\": path, \"objectives\": [objective(point) for point in path]})"
+    "objectives = [objective(point) for point in path]\n",
+    "print(f\"start = {start}; path = {path}; objectives = {objectives}\")\n"
    ]
   },
   {
@@ -1520,7 +1521,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'first_improving': (5.0, 'move_a'), 'best_improving': (2.0, 'move_b')}\n"
+      "first_improving = (5.0, \"move_a\"); best_improving = (2.0, \"move_b\")\n"
      ]
     }
    ],
@@ -1529,8 +1530,12 @@
     "# Compare first-improving and best-improving choices on the same candidate list.\n",
     "candidates = [(5.0, \"move_a\"), (2.0, \"move_b\"), (3.0, \"move_c\")]\n",
     "first_improving = next(candidate for candidate in candidates if candidate[0] < 6.0)\n",
-    "best_improving = min(candidates, key=lambda item: item[0])\n",
-    "print({\"first_improving\": first_improving, \"best_improving\": best_improving})"
+    "best_improving = min(candidates, key=lambda candidate: candidate[0])\n",
+    "def format_candidate(candidate):\n",
+    "    value, label = candidate\n",
+    "    return f'({value}, \"{label}\")'\n",
+    "\n",
+    "print(f\"first_improving = {format_candidate(first_improving)}; best_improving = {format_candidate(best_improving)}\")\n"
    ]
   },
   {
@@ -1577,7 +1582,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'old_gains': [3.0, -3.0, 1.0], 'new_gains': [-3.0, 3.0, 4.0]}\n"
+      "old_gains = [3.0, -3.0, 1.0]; new_gains = [-3.0, 3.0, 4.0]\n"
      ]
     }
    ],
@@ -1590,7 +1595,9 @@
     "def gains(coefficients):\n",
     "    return [sum(c_i * move_i for c_i, move_i in zip(coefficients, move)) for move in moves]\n",
     "\n",
-    "print({\"old_gains\": gains(old_c), \"new_gains\": gains(new_c)})"
+    "old_gains = gains(old_c)\n",
+    "new_gains = gains(new_c)\n",
+    "print(f\"old_gains = {old_gains}; new_gains = {new_gains}\")\n"
    ]
   },
   {

--- a/notebooks_py/4-DWAVE_python.ipynb
+++ b/notebooks_py/4-DWAVE_python.ipynb
@@ -935,8 +935,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'rho': 0.25, 'best': ((0, 0), 0.25), 'feasible': False}\n",
-      "{'rho': 4.0, 'best': ((1, 0), 1.0), 'feasible': True}\n"
+      "rho = 0.25; best = ((0, 0), 0.25); feasible = false\n",
+      "rho = 4.0; best = ((1, 0), 1.0); feasible = true\n"
      ]
     }
    ],
@@ -956,7 +956,8 @@
     "        ((bits, penalty_energy(bits, rho_value)) for bits in itertools.product([0, 1], repeat=2)),\n",
     "        key=lambda item: item[1],\n",
     "    )\n",
-    "    print({\"rho\": rho_value, \"best\": best, \"feasible\": sum(best[0]) == 1})"
+    "    feasible = sum(best[0]) == 1\n",
+    "    print(f\"rho = {rho_value}; best = {best}; feasible = {str(feasible).lower()}\")\n"
    ]
   },
   {
@@ -1003,7 +1004,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{100: -1.0, 500: -1.05, 1000: -1.1}\n"
+      "best_energy_by_reads = {100: -1.0, 500: -1.05, 1000: -1.1}\n"
      ]
     }
    ],
@@ -1015,7 +1016,8 @@
     "    reads: min(-1.0, -1.0 - 0.05 * index)\n",
     "    for index, reads in enumerate(read_counts)\n",
     "}\n",
-    "print(best_energy_by_reads)"
+    "formatted_results = \", \".join(f\"{reads}: {best_energy_by_reads[reads]}\" for reads in read_counts)\n",
+    "print(f\"best_energy_by_reads = {{{formatted_results}}}\")\n"
    ]
   },
   {
@@ -1062,7 +1064,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'chain_lengths': {3: 1, 0: 2, 1: 1, 4: 2, 2: 1, 5: 2, 6: 2, 7: 2, 8: 2, 9: 2, 10: 2}}\n"
+      "QPU embedding metadata is unavailable; use the local fallback result above.\n"
      ]
     }
    ],
@@ -1072,9 +1074,12 @@
     "if globals().get(\"qpu_available\") and \"embedding_context\" in DWaveSamples.info:\n",
     "    embedding = DWaveSamples.info[\"embedding_context\"][\"embedding\"]\n",
     "    chain_lengths = {variable: len(chain) for variable, chain in embedding.items()}\n",
-    "    print({\"chain_lengths\": chain_lengths})\n",
+    "    formatted_lengths = \", \".join(\n",
+    "        f\"{variable}: {chain_lengths[variable]}\" for variable in sorted(chain_lengths)\n",
+    "    )\n",
+    "    print(f\"chain_lengths = {{{formatted_lengths}}}\")\n",
     "else:\n",
-    "    print(\"QPU embedding metadata is unavailable; use the simulated annealing fallback result above.\")"
+    "    print(\"QPU embedding metadata is unavailable; use the local fallback result above.\")\n"
    ]
   },
   {

--- a/notebooks_py/5-Benchmarking_python.ipynb
+++ b/notebooks_py/5-Benchmarking_python.ipynb
@@ -2820,7 +2820,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('new_sampler', {'best_energy': -12.6, 'time': 2.1}), ('baseline_sa', {'best_energy': -12.4, 'time': 1.8})]\n"
+      "solver_results = new_sampler: best_energy=-12.6, time=2.1; baseline_sa: best_energy=-12.4, time=1.8\n"
      ]
     }
    ],
@@ -2831,7 +2831,12 @@
     "    \"baseline_sa\": {\"best_energy\": -12.4, \"time\": 1.8},\n",
     "    \"new_sampler\": {\"best_energy\": -12.6, \"time\": 2.1},\n",
     "}\n",
-    "print(sorted(solver_results.items(), key=lambda item: item[1][\"best_energy\"]))"
+    "sorted_results = sorted(solver_results.items(), key=lambda item: item[1][\"best_energy\"])\n",
+    "formatted_results = [\n",
+    "    f\"{name}: best_energy={metrics['best_energy']}, time={metrics['time']}\"\n",
+    "    for name, metrics in sorted_results\n",
+    "]\n",
+    "print(\"solver_results = \" + \"; \".join(formatted_results))\n"
    ]
   },
   {
@@ -2878,7 +2883,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'target_confidence': 0.99, 'tts_reads': 2900}\n"
+      "target_confidence = 0.99; tts_reads = 2900\n"
      ]
     }
    ],
@@ -2891,7 +2896,7 @@
     "target_confidence = 0.99\n",
     "reads_per_run = 100\n",
     "tts_reads = math.ceil(math.log(1 - target_confidence) / math.log(1 - success_probability)) * reads_per_run\n",
-    "print({\"target_confidence\": target_confidence, \"tts_reads\": tts_reads})"
+    "print(f\"target_confidence = {target_confidence}; tts_reads = {tts_reads}\")\n"
    ]
   },
   {
@@ -2938,7 +2943,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'performance_ratio': 0.75}\n"
+      "performance_ratio = 0.75\n"
      ]
     }
    ],
@@ -2949,7 +2954,7 @@
     "random_energy = -3.0\n",
     "observed_energy = -12.0\n",
     "performance_ratio = (observed_energy - random_energy) / (best_energy - random_energy)\n",
-    "print({\"performance_ratio\": performance_ratio})"
+    "print(f\"performance_ratio = {performance_ratio}\")\n"
    ]
   },
   {

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -613,10 +613,14 @@ class NotebookPythonJuliaParityTests(unittest.TestCase):
                 julia=julia_path.relative_to(REPO_ROOT).as_posix(),
                 python=python_path.relative_to(REPO_ROOT).as_posix(),
             ):
-                self.assertEqual(
-                    notebook_solution_output_texts(julia_path),
-                    notebook_solution_output_texts(python_path),
-                )
+                julia_outputs = notebook_solution_output_texts(julia_path)
+                python_outputs = notebook_solution_output_texts(python_path)
+
+                self.assertEqual(3, len(julia_outputs))
+                self.assertEqual(3, len(python_outputs))
+                self.assertTrue(all(output.strip() for output in julia_outputs))
+                self.assertTrue(all(output.strip() for output in python_outputs))
+                self.assertEqual(julia_outputs, python_outputs)
 
 
 class PythonPlotSamplesNotebookTests(unittest.TestCase):

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -100,6 +100,28 @@ def notebook_cells(path: Path) -> list[dict]:
     return notebook["cells"]
 
 
+def notebook_solution_output_texts(path: Path) -> list[str]:
+    outputs = []
+
+    for cell in notebook_cells(path):
+        source = "".join(cell.get("source", []))
+        if (
+            cell.get("cell_type") == "code"
+            and "# SOLUTION (hidden in workshop version):" in source
+        ):
+            stream_text = []
+            for output in cell.get("outputs", []):
+                if (
+                    output.get("output_type") == "stream"
+                    and output.get("name") == "stdout"
+                ):
+                    text = output.get("text", [])
+                    stream_text.append("".join(text) if isinstance(text, list) else text)
+            outputs.append("".join(stream_text))
+
+    return outputs
+
+
 def notebook_paths() -> list[Path]:
     return sorted(path for directory in NOTEBOOK_DIRS for path in directory.glob("*.ipynb"))
 
@@ -574,6 +596,27 @@ class NotebookPedagogyCellTests(unittest.TestCase):
                     self.assertEqual(reference_indices[0] - 1, summary_index)
                 else:
                     self.assertEqual(len(cells) - 1, summary_index)
+
+
+class NotebookPythonJuliaParityTests(unittest.TestCase):
+    def test_practice_checkpoint_outputs_match_language_pairs(self) -> None:
+        paired_notebooks = (
+            (MATHPROG_JULIA_NOTEBOOK_PATH, MATHPROG_NOTEBOOK_PATH),
+            (QUBO_JULIA_NOTEBOOK_PATH, QUBO_NOTEBOOK_PATH),
+            (GAMA_JULIA_NOTEBOOK_PATH, GAMA_NOTEBOOK_PATH),
+            (DWAVE_JULIA_NOTEBOOK_PATH, DWAVE_PYTHON_NOTEBOOK_PATH),
+            (BENCHMARKING_JULIA_NOTEBOOK_PATH, BENCHMARKING_PYTHON_NOTEBOOK_PATH),
+        )
+
+        for julia_path, python_path in paired_notebooks:
+            with self.subTest(
+                julia=julia_path.relative_to(REPO_ROOT).as_posix(),
+                python=python_path.relative_to(REPO_ROOT).as_posix(),
+            ):
+                self.assertEqual(
+                    notebook_solution_output_texts(julia_path),
+                    notebook_solution_output_texts(python_path),
+                )
 
 
 class PythonPlotSamplesNotebookTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Align the practice-checkpoint result displays across every notebook that has both a Julia and Python version:

- MathProg
- QUBO and Ising
- GAMA
- D-Wave
- Benchmarking

The checkpoint cells now print the same compact result text in both languages. This removes distracting differences such as Julia named tuples versus Python dicts, Python zero-based graph-color labels versus Julia one-based labels, and stale QPU-specific D-Wave checkpoint output.

## Impact

Readers comparing the Julia and Python notebook tracks see the same deterministic checkpoint answers for paired material. Solver-dependent and long-running cells are left alone.

## Validation

- `python -m unittest discover -s tests`
- `make verify-qubo-python`
- `make verify-gama-python` (rerun outside the sandbox after Jupyter local socket creation was blocked)
- Python checkpoint solution cells compile
- Julia checkpoint solution cells parse with `Meta.parse`
- `git diff --check`
