### PR TITLE
[codex] Fix Julia Colab notebook bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ long benchmark runs.
 
 | Topic | Julia notebook | Python notebook | Local verification status |
 | --- | --- | --- | --- |
-| Linear and Integer Programming | [notebooks_jl/1-MathProg.ipynb](notebooks_jl/1-MathProg.ipynb) | [notebooks_py/1-MathProg_python.ipynb](notebooks_py/1-MathProg_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; local execution requires LP/NLP/MINLP solver binaries. |
-| QUBO and Ising | [notebooks_jl/2-QUBO.ipynb](notebooks_jl/2-QUBO.ipynb) | [notebooks_py/2-QUBO_python.ipynb](notebooks_py/2-QUBO_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-qubo-python`. |
-| Graver Augmented Multiseed Algorithm | [notebooks_jl/3-GAMA.ipynb](notebooks_jl/3-GAMA.ipynb) | [notebooks_py/3-GAMA_python.ipynb](notebooks_py/3-GAMA_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; Python notebook is portable and covered by `make verify-gama-python`. |
-| D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; quantum annealer cells require D-Wave solver access. The Python D-Wave notebook requires a user-managed Ocean install and is not part of the locked Python verification environment. |
-| Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Julia notebook includes Colab setup through the shared sysimage; benchmark runs are long-running and generate artifacts. |
+| Linear and Integer Programming | [notebooks_jl/1-MathProg.ipynb](notebooks_jl/1-MathProg.ipynb) | [notebooks_py/1-MathProg_python.ipynb](notebooks_py/1-MathProg_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; local execution requires LP/NLP/MINLP solver binaries. |
+| QUBO and Ising | [notebooks_jl/2-QUBO.ipynb](notebooks_jl/2-QUBO.ipynb) | [notebooks_py/2-QUBO_python.ipynb](notebooks_py/2-QUBO_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; Python notebook is portable and covered by `make verify-qubo-python`. |
+| Graver Augmented Multiseed Algorithm | [notebooks_jl/3-GAMA.ipynb](notebooks_jl/3-GAMA.ipynb) | [notebooks_py/3-GAMA_python.ipynb](notebooks_py/3-GAMA_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; Python notebook is portable and covered by `make verify-gama-python`. |
+| D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; quantum annealer cells require D-Wave solver access. The Python D-Wave notebook requires a user-managed Ocean install and is not part of the locked Python verification environment. |
+| Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; benchmark runs are long-running and generate artifacts. |
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
 
 ## Local verification
@@ -73,8 +73,9 @@ solver credentials or longer-running jobs; those credentialed and long-running
 notebooks are not part of the default portable subset. The QCi notebook does
 not yet have a locked local make target because `eqc-models==0.19.0` requires
 `networkx<3`, which conflicts with the D-Wave Ocean stack.
-The Julia notebooks use `scripts/install-colab-julia.sh` in Colab to install
-Julia and the latest precompiled QUBONotebooks sysimage.
+The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
+repository when needed, activate `notebooks_jl`, and resolve the checked-in
+manifest for the current hosted Julia runtime.
 
 ```bash
 make verify-notebooks NOTEBOOKS="notebooks_py/2-QUBO_python.ipynb" UV_GROUP_FLAGS="--group docs --group qubo"

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -69,8 +69,8 @@
     "If not in a Colab notebook, continue to the next section.\n",
     "\n",
     "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
-    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
-    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+    "2. Make sure the runtime is set to **Julia**. If Colab opens a Python runtime, use _Runtime_ > _Change runtime type_ and select Julia.\n",
+    "3. Execute the following setup cell to clone the repository when needed, activate the shared notebook project, and install dependencies. The first Colab run can take several minutes.\n"
    ]
   },
   {
@@ -79,9 +79,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%shell\n",
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
     "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"1-MathProg\")\n",
+    "\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab\n"
    ]
   },
   {
@@ -114,12 +148,18 @@
    ],
    "source": [
     "import Pkg\n",
-    "Pkg.activate(@__DIR__)\n",
+    "\n",
     "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
     "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
     "if python_warning_filter ∉ python_warning_filters\n",
     "    push!(python_warning_filters, python_warning_filter)\n",
     "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
     "end\n",
     "Pkg.instantiate(; io = devnull)\n"
    ]
@@ -2068,9 +2108,9 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": "Julia 1.11.5",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -69,21 +69,53 @@
     "If not in a Colab notebook, continue to the next section.\n",
     "\n",
     "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
-    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
-    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+    "2. Make sure the runtime is set to **Julia**. If Colab opens a Python runtime, use _Runtime_ > _Change runtime type_ and select Julia.\n",
+    "3. Execute the following setup cell to clone the repository when needed, activate the shared notebook project, and install dependencies. The first Colab run can take several minutes.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "colab-install-julia"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%%shell\n",
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
     "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"2-QUBO\")\n",
+    "\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab\n"
    ]
   },
   {
@@ -117,12 +149,18 @@
    ],
    "source": [
     "import Pkg\n",
-    "Pkg.activate(@__DIR__)\n",
+    "\n",
     "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
     "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
     "if python_warning_filter ∉ python_warning_filters\n",
     "    push!(python_warning_filters, python_warning_filter)\n",
     "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
     "end\n",
     "Pkg.instantiate(; io = devnull)\n"
    ]
@@ -3015,9 +3053,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Julia 1.12",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.12"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -65,8 +65,8 @@
     "If not in a Colab notebook, continue to the next section.\n",
     "\n",
     "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
-    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
-    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+    "2. Make sure the runtime is set to **Julia**. If Colab opens a Python runtime, use _Runtime_ > _Change runtime type_ and select Julia.\n",
+    "3. Execute the following setup cell to clone the repository when needed, activate the shared notebook project, and install dependencies. The first Colab run can take several minutes.\n"
    ]
   },
   {
@@ -75,9 +75,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%shell\n",
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
     "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"3-GAMA\")\n",
+    "\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab\n"
    ]
   },
   {
@@ -110,12 +144,18 @@
    ],
    "source": [
     "import Pkg\n",
-    "Pkg.activate(@__DIR__)\n",
+    "\n",
     "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
     "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
     "if python_warning_filter ∉ python_warning_filters\n",
     "    push!(python_warning_filters, python_warning_filter)\n",
     "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
     "end\n",
     "Pkg.instantiate(; io = devnull)\n"
    ]
@@ -1746,9 +1786,9 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": "Julia 1.11.5",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -54,15 +54,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"installation\" id=\"installation\"></a>\n",
-    "\n",
     "## Colab Instructions\n",
     "\n",
     "If not in a Colab notebook, continue to the next section.\n",
     "\n",
     "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
-    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
-    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+    "2. Make sure the runtime is set to **Julia**. If Colab opens a Python runtime, use _Runtime_ > _Change runtime type_ and select Julia.\n",
+    "3. Execute the following setup cell to clone the repository when needed, activate the shared notebook project, and install dependencies. The first Colab run can take several minutes.\n"
    ]
   },
   {
@@ -71,9 +69,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%shell\n",
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
     "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"4-DWave\")\n",
+    "\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab\n"
    ]
   },
   {
@@ -106,12 +138,18 @@
    ],
    "source": [
     "import Pkg\n",
-    "Pkg.activate(@__DIR__)\n",
+    "\n",
     "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
     "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
     "if python_warning_filter ∉ python_warning_filters\n",
     "    push!(python_warning_filters, python_warning_filter)\n",
     "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
     "end\n",
     "Pkg.instantiate(; io = devnull)\n"
    ]
@@ -1170,9 +1208,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.11.5",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -54,6 +54,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"installation\" id=\"installation\"></a>\n",
+    "\n",
     "## Colab Instructions\n",
     "\n",
     "If not in a Colab notebook, continue to the next section.\n",

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -61,26 +61,53 @@
     "If not in a Colab notebook, continue to the next section.\n",
     "\n",
     "1. Work on a copy of this notebook: _File_ > _Save a copy in Drive_.\n",
-    "2. Execute the following cell to install Julia, IJulia, the shared notebook project, and the precompiled QUBONotebooks sysimage. This can take a couple of minutes.\n",
-    "3. Reload this page after the installation finishes, then continue with **Activate Environment**.\n"
+    "2. Make sure the runtime is set to **Julia**. If Colab opens a Python runtime, use _Runtime_ > _Change runtime type_ and select Julia.\n",
+    "3. Execute the following setup cell to clone the repository when needed, activate the shared notebook project, and install dependencies. The first Colab run can take several minutes.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-09T16:49:26.371000Z",
-     "iopub.status.busy": "2026-07-09T16:49:26.371000Z",
-     "iopub.status.idle": "2026-07-09T16:49:26.372000Z",
-     "shell.execute_reply": "2026-07-09T16:49:26.372000Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%%shell\n",
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
     "\n",
-    "bash <(curl -s \"https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/scripts/install-colab-julia.sh\")"
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"5-Benchmarking\")\n",
+    "\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab\n"
    ]
   },
   {
@@ -113,12 +140,18 @@
    ],
    "source": [
     "import Pkg\n",
-    "Pkg.activate(@__DIR__)\n",
+    "\n",
     "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
     "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
     "if python_warning_filter ∉ python_warning_filters\n",
     "    push!(python_warning_filters, python_warning_filter)\n",
     "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
     "end\n",
     "Pkg.instantiate(; io = devnull)\n"
    ]
@@ -4511,9 +4544,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.12 1.12",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.12-1.12"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -1,0 +1,411 @@
+module QUBONotebooksBootstrap
+
+using Dates
+using Logging
+import Pkg
+import TOML
+
+const WORKSPACE = normpath(joinpath(@__DIR__, ".."))
+const NOTEBOOKS_DIRNAME = "notebooks_jl"
+const ALLOW_VERSION_MISMATCH_ENV = "QUBONOTEBOOKS_ALLOW_JULIA_VERSION_MISMATCH"
+const REPO_REF_ENV = "QUBONOTEBOOKS_REPO_REF"
+const PYTHON_STACK_NOTEBOOKS = Set((
+    "2-QUBO",
+    "3-GAMA",
+    "4-DWave",
+    "5-Benchmarking",
+))
+const NOTEBOOK_IMPORTS = Dict(
+    "1-MathProg" => :(using Plots, JuMP, GLPK, Cbc, Ipopt, SpecialFunctions, AmplNLWriter, Bonmin_jll, Couenne_jll),
+    "2-QUBO" => :(using Karnak, LinearAlgebra, Graphs, JuMP, QUBO, Plots, GLPK, DWave, Luxor),
+    "3-GAMA" => :(using BinaryWrappers, DelimitedFiles, Downloads, NPZ, JuMP, DWave, LinearAlgebra, Measures, Random, Plots, StatsBase, StatsPlots, lib4ti2_jll),
+    "4-DWave" => :(using LinearAlgebra, Plots, JuMP, QUBO, DWave, Graphs),
+    "5-Benchmarking" => :(using JuMP, QUBO, LinearAlgebra, Plots, Measures, DWave, Random, Statistics, ZipFile, JSON, StatsBase),
+)
+
+timestamp() = Dates.format(now(), "HH:MM:SS")
+
+function log_step(message::AbstractString)
+    println("[$(timestamp())] $message")
+    flush(stdout)
+    return nothing
+end
+
+function detect_colab()
+    return haskey(ENV, "COLAB_RELEASE_TAG") ||
+        haskey(ENV, "COLAB_JUPYTER_IP") ||
+        isdir(joinpath("/content", "sample_data"))
+end
+
+function env_bool(name::AbstractString)
+    value = get(ENV, name, nothing)
+    value === nothing && return nothing
+
+    normalized = lowercase(strip(value))
+    if normalized in ("1", "true", "yes", "on")
+        return true
+    elseif normalized in ("0", "false", "no", "off")
+        return false
+    end
+
+    error("Expected `$name` to be one of 1/0/true/false/yes/no/on/off, got `$value`.")
+end
+
+default_bootstrap_warm_packages(; in_colab::Bool = detect_colab()) =
+    something(env_bool("QUBONOTEBOOKS_WARM_PACKAGES"), in_colab)
+
+default_bootstrap_precompile(;
+    in_colab::Bool = detect_colab(),
+    warm_packages::Bool = default_bootstrap_warm_packages(in_colab = in_colab),
+) = in_colab && !warm_packages
+
+function notebook_key(target::AbstractString)
+    return splitext(basename(target))[1]
+end
+
+function notebook_requires_python(project_key::AbstractString)
+    return project_key in PYTHON_STACK_NOTEBOOKS
+end
+
+notebook_import_expr(project_key::AbstractString) = get(NOTEBOOK_IMPORTS, project_key, nothing)
+
+function notebook_project_dir(; repo_dir::AbstractString = WORKSPACE)
+    return joinpath(repo_dir, NOTEBOOKS_DIRNAME)
+end
+
+function manifest_path(project_dir::AbstractString)
+    return joinpath(project_dir, "Manifest.toml")
+end
+
+function manifest_julia_version(project_dir::AbstractString)
+    path = manifest_path(project_dir)
+    if !isfile(path)
+        return nothing
+    end
+
+    manifest = TOML.parsefile(path)
+    version_string = get(manifest, "julia_version", nothing)
+    return version_string === nothing ? nothing : VersionNumber(version_string)
+end
+
+function requested_repo_ref()
+    value = strip(get(ENV, REPO_REF_ENV, ""))
+    return isempty(value) ? nothing : value
+end
+
+is_full_commit_sha(repo_ref::AbstractString) = occursin(r"^[0-9a-fA-F]{40}$", strip(repo_ref))
+
+function repo_remote_url(repo_dir::AbstractString)
+    return strip(readchomp(`git -C $repo_dir remote get-url origin`))
+end
+
+function resolve_repo_ref(repo_dir::AbstractString, repo_ref::AbstractString)
+    remote_url = repo_remote_url(repo_dir)
+    normalized_ref = strip(repo_ref)
+
+    if is_full_commit_sha(normalized_ref)
+        return (
+            remote_url = remote_url,
+            requested_sha = lowercase(normalized_ref),
+            fetch_ref = normalized_ref,
+            is_direct_sha = true,
+        )
+    end
+
+    requested_ref = readchomp(`git ls-remote $remote_url $normalized_ref`)
+    requested_sha = isempty(requested_ref) ? nothing : first(split(requested_ref))
+    if requested_sha === nothing
+        error("Could not resolve `$repo_ref` against `$remote_url`.")
+    end
+
+    return (
+        remote_url = remote_url,
+        requested_sha = lowercase(requested_sha),
+        fetch_ref = normalized_ref,
+        is_direct_sha = false,
+    )
+end
+
+function checkout_repo_ref!(repo_dir::AbstractString, repo_ref::AbstractString)
+    current_ref = lowercase(readchomp(`git -C $repo_dir rev-parse HEAD`))
+    resolved = resolve_repo_ref(repo_dir, repo_ref)
+
+    if current_ref == resolved.requested_sha
+        return nothing
+    end
+
+    known_commit_cmd = Cmd([
+        "git",
+        "-C",
+        repo_dir,
+        "cat-file",
+        "-e",
+        "$(resolved.requested_sha)^{commit}",
+    ])
+    if resolved.is_direct_sha && success(known_commit_cmd)
+        log_step("Checking out QUBONotebooks commit: $(resolved.requested_sha)")
+        run(`git -C $repo_dir checkout --detach $(resolved.requested_sha)`)
+        return nothing
+    end
+
+    log_step("Checking out QUBONotebooks ref: $repo_ref")
+    run(`git -C $repo_dir fetch --depth 1 $(resolved.remote_url) $(resolved.fetch_ref)`)
+
+    fetched_sha = lowercase(readchomp(`git -C $repo_dir rev-parse FETCH_HEAD`))
+    if fetched_sha != resolved.requested_sha
+        error("Resolved `$repo_ref` to $(resolved.requested_sha), but fetch from `$(resolved.remote_url)` produced $fetched_sha.")
+    end
+
+    run(`git -C $repo_dir checkout --detach $(resolved.requested_sha)`)
+    return nothing
+end
+
+function validate_project_julia_version!(project_dir::AbstractString; in_colab::Bool = detect_colab())
+    manifest_version = manifest_julia_version(project_dir)
+    manifest_version === nothing && return nothing
+    manifest_version == VERSION && return nothing
+
+    configured_allow_mismatch = env_bool(ALLOW_VERSION_MISMATCH_ENV)
+    allow_mismatch = something(configured_allow_mismatch, in_colab)
+    message = "The Julia manifest at $(manifest_path(project_dir)) targets Julia $(manifest_version), but the current kernel is Julia $(VERSION)."
+
+    if in_colab && !allow_mismatch
+        error(message * " Set $(ALLOW_VERSION_MISMATCH_ENV)=1 to allow a slower re-resolve.")
+    end
+
+    reason = in_colab ? "Colab will allow Pkg to re-resolve the notebook environment" : "Colab mode is disabled"
+    configured_allow_mismatch === true && (reason = "$(ALLOW_VERSION_MISMATCH_ENV)=1")
+    @warn message * " Continuing because $reason."
+    return nothing
+end
+
+function should_resolve_project_for_current_julia(project_dir::AbstractString; in_colab::Bool = detect_colab())
+    manifest_version = manifest_julia_version(project_dir)
+    return in_colab && manifest_version !== nothing && manifest_version != VERSION
+end
+
+function resolve_project_for_current_julia!(project_dir::AbstractString; in_colab::Bool = detect_colab())
+    should_resolve_project_for_current_julia(project_dir; in_colab = in_colab) || return false
+
+    if in_colab
+        get!(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "0")
+    end
+    log_step("Resolving Julia packages for current runtime Julia $(VERSION)")
+    try
+        Pkg.resolve()
+    catch err
+        if !in_colab
+            rethrow()
+        end
+
+        @warn "Pkg.resolve() could not refresh $(manifest_path(project_dir)); updating Julia packages for current runtime Julia $(VERSION)." exception = (err, catch_backtrace())
+        log_step("Updating Julia packages for current runtime Julia $(VERSION)")
+        Pkg.update()
+    end
+    return true
+end
+
+function candidate_repo_dirs(; cwd::AbstractString = pwd())
+    return unique((
+        normpath(cwd),
+        normpath(cwd, ".."),
+        normpath(cwd, "QUBONotebooks"),
+        normpath(cwd, "..", "QUBONotebooks"),
+        normpath("/content", "QUBONotebooks"),
+        WORKSPACE,
+    ))
+end
+
+function is_repo_root(path::AbstractString)
+    return isfile(joinpath(path, "scripts", "notebook_bootstrap.jl")) &&
+        isdir(joinpath(path, NOTEBOOKS_DIRNAME))
+end
+
+function find_repo_root(; cwd::AbstractString = pwd())
+    for candidate in candidate_repo_dirs(cwd = cwd)
+        if is_repo_root(candidate)
+            return normpath(candidate)
+        end
+    end
+    return nothing
+end
+
+function ensure_repo_root(; in_colab::Bool = detect_colab())
+    repo_dir = find_repo_root()
+    repo_ref = requested_repo_ref()
+    if repo_dir !== nothing
+        if repo_ref !== nothing
+            checkout_repo_ref!(repo_dir, repo_ref)
+        end
+        return repo_dir
+    end
+
+    if !in_colab
+        error("Could not locate the QUBONotebooks repository root from $(pwd()).")
+    end
+
+    repo_dir = get(ENV, "QUBONOTEBOOKS_REPO_DIR", joinpath(pwd(), "QUBONotebooks"))
+    if !isdir(repo_dir)
+        log_step("Cloning JuliaQUBO/QUBONotebooks into $repo_dir")
+        run(`git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git $repo_dir`)
+    else
+        log_step("Using existing QUBONotebooks clone at $repo_dir")
+    end
+
+    if repo_ref !== nothing
+        checkout_repo_ref!(repo_dir, repo_ref)
+    end
+
+    if !is_repo_root(repo_dir)
+        error("The repository at $repo_dir does not contain the expected Julia notebook bootstrap files.")
+    end
+
+    ENV["QUBONOTEBOOKS_REPO_DIR"] = normpath(repo_dir)
+    return normpath(repo_dir)
+end
+
+function configure_python_runtime!(
+    repo_dir::AbstractString;
+    in_colab::Bool = detect_colab(),
+    python_packages::Vector{String} = ["dwave-ocean-sdk"],
+)
+    ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
+
+    if in_colab
+        if !isempty(python_packages)
+            log_step("Installing Python packages: $(join(python_packages, ", "))")
+            run(`python3 -m pip install -q $(python_packages...)`)
+        end
+        python_exe = something(Sys.which("python3"), "python3")
+    else
+        python_exe = joinpath(repo_dir, ".venv", "bin", "python3")
+        if !isfile(python_exe)
+            error("Could not find $python_exe. Run `uv sync --group qubo` from the repository root before launching this notebook.")
+        end
+    end
+
+    ENV["JULIA_PYTHONCALL_EXE"] = python_exe
+    log_step("Using Python runtime: $python_exe")
+    return python_exe
+end
+
+function activate_project!(project_dir::AbstractString)
+    log_step("Activating project at `$project_dir`")
+    Pkg.activate(project_dir)
+    return nothing
+end
+
+function instantiate_project!(project_dir::AbstractString; precompile::Bool = true)
+    activate_project!(project_dir)
+    refreshed_for_current_julia = resolve_project_for_current_julia!(project_dir)
+    log_step("Instantiating Julia packages")
+    @time Pkg.instantiate()
+    if precompile
+        log_step("Precompiling Julia packages")
+        @time Pkg.precompile()
+    end
+    return refreshed_for_current_julia
+end
+
+function warm_notebook_packages!(
+    project_key::AbstractString;
+    suppress_logs::Bool = true,
+)
+    import_expr = notebook_import_expr(project_key)
+    import_expr === nothing && return false
+
+    log_step("Loading notebook packages")
+    if suppress_logs
+        with_logger(NullLogger()) do
+            Core.eval(Main, import_expr)
+        end
+    else
+        Core.eval(Main, import_expr)
+    end
+    return true
+end
+
+function bootstrap_notebook(
+    project_key::AbstractString;
+    needs_python::Bool = notebook_requires_python(project_key),
+    python_packages::Vector{String} = ["dwave-ocean-sdk"],
+    warm_packages::Bool = default_bootstrap_warm_packages(),
+    precompile::Bool = default_bootstrap_precompile(in_colab = detect_colab(), warm_packages = warm_packages),
+    suppress_warmup_logs::Bool = warm_packages,
+    chdir_to_notebooks::Bool = true,
+)
+    in_colab = detect_colab()
+    repo_dir = ensure_repo_root(in_colab = in_colab)
+    notebooks_dir = joinpath(repo_dir, NOTEBOOKS_DIRNAME)
+    project_dir = notebook_project_dir(repo_dir = repo_dir)
+
+    if !isdir(project_dir)
+        error("Notebook project was not found at $project_dir.")
+    end
+
+    log_step("Notebook project key: $project_key")
+    log_step("Google Colab runtime detected: $(in_colab)")
+    if in_colab
+        manifest_version = manifest_julia_version(project_dir)
+        if manifest_version !== nothing
+            log_step("Manifest Julia version: $(manifest_version)")
+        end
+    end
+    validate_project_julia_version!(project_dir; in_colab = in_colab)
+
+    if needs_python
+        configure_python_runtime!(repo_dir; in_colab = in_colab, python_packages = python_packages)
+    end
+
+    refreshed_for_current_julia = instantiate_project!(project_dir; precompile = precompile)
+    if warm_packages && refreshed_for_current_julia
+        log_step("Skipping package warmup because the notebook environment was refreshed for Julia $(VERSION). Restart the runtime and rerun this setup cell for a clean package load before continuing.")
+    elseif warm_packages
+        warm_notebook_packages!(project_key; suppress_logs = suppress_warmup_logs)
+    end
+
+    if chdir_to_notebooks
+        cd(notebooks_dir)
+        log_step("Working directory set to $notebooks_dir")
+    end
+
+    log_step("Notebook bootstrap complete")
+    return (
+        repo_dir = repo_dir,
+        notebooks_dir = notebooks_dir,
+        project_dir = project_dir,
+        in_colab = in_colab,
+    )
+end
+
+function instantiate_notebook_project(
+    target::AbstractString;
+    precompile::Bool = false,
+    needs_python::Bool = notebook_requires_python(notebook_key(target)),
+)
+    project_key = notebook_key(target)
+    repo_dir = ensure_repo_root(in_colab = false)
+    project_dir = notebook_project_dir(repo_dir = repo_dir)
+
+    if needs_python
+        configure_python_runtime!(repo_dir; in_colab = false, python_packages = String[])
+    end
+
+    validate_project_julia_version!(project_dir; in_colab = false)
+    instantiate_project!(project_dir; precompile = precompile)
+    return project_dir
+end
+
+function instantiate_scripts_project(; precompile::Bool = false)
+    repo_dir = ensure_repo_root(in_colab = false)
+    project_dir = joinpath(repo_dir, "scripts")
+
+    if !isdir(project_dir)
+        error("Scripts project was not found at $project_dir.")
+    end
+
+    instantiate_project!(project_dir; precompile = precompile)
+    return project_dir
+end
+
+end

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -37,10 +37,7 @@ JULIA_COLAB_NOTEBOOK_PATHS = (
     REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb",
     REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb",
 )
-COLAB_JULIA_INSTALLER = (
-    'bash <(curl -s "https://raw.githubusercontent.com/JuliaQUBO/QUBONotebooks/main/'
-    'scripts/install-colab-julia.sh")'
-)
+BOOTSTRAP_PATH = REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
 NOTEBOOK_DIRS = (
     REPO_ROOT / "notebooks_jl",
     REPO_ROOT / "notebooks_py",
@@ -1373,21 +1370,53 @@ class RepositoryCommandTests(unittest.TestCase):
 
 
 class JuliaColabSetupTests(unittest.TestCase):
-    def test_all_julia_notebooks_install_colab_julia_before_activation(self) -> None:
+    def test_all_julia_notebooks_use_native_colab_julia_bootstrap(self) -> None:
         for path in JULIA_COLAB_NOTEBOOK_PATHS:
             with self.subTest(path=path.relative_to(REPO_ROOT).as_posix()):
                 cells = notebook_cell_sources(path)
-                install_indexes = [
-                    i for i, source in enumerate(cells) if COLAB_JULIA_INSTALLER in source
+                setup_indexes = [
+                    i
+                    for i, source in enumerate(cells)
+                    if (
+                        "Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook"
+                        in source
+                    )
                 ]
                 activate_indexes = [
-                    i for i, source in enumerate(cells) if "Pkg.activate(@__DIR__)" in source
+                    i for i, source in enumerate(cells) if "Pkg.activate(JULIA_PROJECT_DIR)" in source
                 ]
+                expected_call = (
+                    "Base.invokelatest("
+                    f'QUBONotebooksBootstrap.bootstrap_notebook, "{path.stem}")'
+                )
+                metadata = json.loads(path.read_text())["metadata"]["kernelspec"]
 
-                self.assertEqual(1, len(install_indexes))
+                self.assertEqual(1, len(setup_indexes))
+                self.assertIn(expected_call, cells[setup_indexes[0]])
                 self.assertTrue(activate_indexes)
-                self.assertLess(install_indexes[0], min(activate_indexes))
-                self.assertIn("precompiled QUBONotebooks sysimage", cells[install_indexes[0] - 1])
+                self.assertLess(setup_indexes[0], min(activate_indexes))
+                self.assertNotIn("%%shell", notebook_source(path))
+                self.assertNotIn("install-colab-julia.sh", notebook_source(path))
+                self.assertEqual(
+                    {"display_name": "Julia", "language": "julia", "name": "julia"},
+                    metadata,
+                )
+
+    def test_bootstrap_supports_native_colab_runtime_failure_modes(self) -> None:
+        source = BOOTSTRAP_PATH.read_text()
+
+        self.assertIn("module QUBONotebooksBootstrap", source)
+        self.assertIn("COLAB_RELEASE_TAG", source)
+        self.assertIn("git clone --depth 1 https://github.com/JuliaQUBO/QUBONotebooks.git", source)
+        self.assertIn("QUBONOTEBOOKS_REPO_DIR", source)
+        self.assertIn("Base.invokelatest", notebook_source(MATHPROG_JULIA_NOTEBOOK_PATH))
+        self.assertIn("configured_allow_mismatch = env_bool(ALLOW_VERSION_MISMATCH_ENV)", source)
+        self.assertIn("Colab will allow Pkg to re-resolve the notebook environment", source)
+        self.assertIn("Resolving Julia packages for current runtime Julia", source)
+        self.assertIn("Pkg.resolve()", source)
+        self.assertIn("Pkg.update()", source)
+        self.assertIn('ENV["JULIA_CONDAPKG_BACKEND"] = "Null"', source)
+        self.assertIn('python_packages::Vector{String} = ["dwave-ocean-sdk"]', source)
 
 
 class PythonNotebookDependencySetupTests(unittest.TestCase):

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -1402,6 +1402,12 @@ class JuliaColabSetupTests(unittest.TestCase):
                     metadata,
                 )
 
+    def test_dwave_installation_badge_targets_existing_anchor(self) -> None:
+        source = notebook_source(DWAVE_JULIA_NOTEBOOK_PATH)
+
+        self.assertIn('href="#installation"', source)
+        self.assertRegex(source, r'<a\b[^>]*(?:id|name)="installation"')
+
     def test_bootstrap_supports_native_colab_runtime_failure_modes(self) -> None:
         source = BOOTSTRAP_PATH.read_text()
 


### PR DESCRIPTION
## Summary
- replace the Julia notebooks' Colab shell installer cell with a native Julia bootstrap cell
- add `scripts/notebook_bootstrap.jl` to locate or clone the repo, activate `notebooks_jl`, tolerate hosted Julia runtime manifest mismatches, and configure the D-Wave Python runtime
- normalize Julia notebook kernelspec metadata to Colab's generic `julia` kernel and update regression tests/docs

## Root Cause
The Julia notebooks still used an IPython-style `%%shell` setup cell and version-specific kernelspec names. In a hosted Julia Colab runtime, that setup cell can fail immediately before the notebook has a chance to activate the Julia project.

## Validation
- `python -m unittest discover -s tests`
- `make test`
- `make test-julia`
- `julia --project=./scripts -e 'include("./scripts/notebook_bootstrap.jl"); using .QUBONotebooksBootstrap; QUBONotebooksBootstrap.bootstrap_notebook("1-MathProg"; warm_packages=false, precompile=false, chdir_to_notebooks=false)'`
- `julia --project=./scripts -e 'include("./scripts/notebook_bootstrap.jl"); using .QUBONotebooksBootstrap; QUBONotebooksBootstrap.bootstrap_notebook("2-QUBO"; warm_packages=false, precompile=false, chdir_to_notebooks=false)'`
