### PR TITLE
[codex] Fix Colab stdlib manifest refresh

### DIFF
--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -184,11 +184,51 @@ function should_resolve_project_for_current_julia(project_dir::AbstractString; i
     return in_colab && manifest_version !== nothing && manifest_version != VERSION
 end
 
+active_stdlib_names() = Set(readdir(Base.load_path_expand("@stdlib")))
+
+function strip_manifest_stdlib_pins!(project_dir::AbstractString; stdlib_names = active_stdlib_names())
+    path = manifest_path(project_dir)
+    isfile(path) || return false
+
+    manifest = TOML.parsefile(path)
+    deps = get(manifest, "deps", nothing)
+    deps isa AbstractDict || return false
+
+    changed = String[]
+    for (name, entries) in deps
+        name in stdlib_names || continue
+        entries isa AbstractVector || continue
+
+        for entry in entries
+            entry isa AbstractDict || continue
+            removed_pin = false
+            if haskey(entry, "version")
+                delete!(entry, "version")
+                removed_pin = true
+            end
+            if haskey(entry, "git-tree-sha1")
+                delete!(entry, "git-tree-sha1")
+                removed_pin = true
+            end
+            removed_pin && push!(changed, String(name))
+        end
+    end
+
+    isempty(changed) && return false
+
+    log_step("Removing stale Julia stdlib pins before resolving: $(join(sort(unique(changed)), ", "))")
+    open(path, "w") do io
+        TOML.print(io, manifest, sorted = true)
+    end
+    return true
+end
+
 function resolve_project_for_current_julia!(project_dir::AbstractString; in_colab::Bool = detect_colab())
     should_resolve_project_for_current_julia(project_dir; in_colab = in_colab) || return false
 
     if in_colab
         get!(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "0")
+        strip_manifest_stdlib_pins!(project_dir)
     end
     log_step("Resolving Julia packages for current runtime Julia $(VERSION)")
     try
@@ -358,9 +398,7 @@ function bootstrap_notebook(
     end
 
     refreshed_for_current_julia = instantiate_project!(project_dir; precompile = precompile)
-    if warm_packages && refreshed_for_current_julia
-        log_step("Skipping package warmup because the notebook environment was refreshed for Julia $(VERSION). Restart the runtime and rerun this setup cell for a clean package load before continuing.")
-    elseif warm_packages
+    if warm_packages
         warm_notebook_packages!(project_key; suppress_logs = suppress_warmup_logs)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
+import TOML
 
 repo_root = dirname(@__DIR__)
+include(joinpath(repo_root, "scripts", "notebook_bootstrap.jl"))
 
 files_with_qubo_links = [
     "README.md",
@@ -115,4 +117,43 @@ end
 
     @test occursin("gprev = fill(typemin(Int), n)", contents)
     @test !occursin("gprev = Vector{Int}(undef, n)", contents)
+end
+
+@testset "Julia Colab stdlib manifest sanitization" begin
+    mktempdir() do dir
+        project_dir = joinpath(dir, "notebooks_jl")
+        mkpath(project_dir)
+        manifest = joinpath(project_dir, "Manifest.toml")
+
+        write(
+            manifest,
+            """
+            julia_version = "1.10.11"
+            manifest_format = "2.0"
+
+            [[deps.ExamplePackage]]
+            git-tree-sha1 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            version = "1.2.3"
+
+            [[deps.Statistics]]
+            deps = ["LinearAlgebra", "SparseArrays"]
+            git-tree-sha1 = "cccccccccccccccccccccccccccccccccccccccc"
+            uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+            version = "1.10.0"
+            """,
+        )
+
+        @test QUBONotebooksBootstrap.strip_manifest_stdlib_pins!(project_dir)
+
+        parsed = TOML.parsefile(manifest)
+        statistics_entry = only(parsed["deps"]["Statistics"])
+        package_entry = only(parsed["deps"]["ExamplePackage"])
+
+        @test !haskey(statistics_entry, "version")
+        @test !haskey(statistics_entry, "git-tree-sha1")
+        @test package_entry["version"] == "1.2.3"
+        @test package_entry["git-tree-sha1"] == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        @test !QUBONotebooksBootstrap.strip_manifest_stdlib_pins!(project_dir)
+    end
 end


### PR DESCRIPTION
## Summary

This fixes the Julia notebook bootstrap path used when Colab runs a newer Julia than the checked-in notebook manifest.

The 1.10.11 manifest can carry versioned stdlib entries such as `Statistics = 1.10.0`. When Colab runs Julia 1.12.6, `Pkg.resolve()` treats those stale stdlib entries as explicit manifest requirements and fails before refreshing the environment. The previous fallback to `Pkg.update()` refreshed much more of the notebook project and could leave later imports such as `Cbc`, `GLPK`, `Karnak`, and `JuMP` failing during precompile/load.

## Changes

- Strip stale `version` and `git-tree-sha1` pins from manifest entries that are stdlibs in the active Julia runtime before resolving in Colab mismatch mode.
- Continue warming notebook packages after a successful mismatch refresh instead of requiring a runtime restart before package load.
- Add a focused Julia regression test for stdlib manifest sanitization.

## Validation

- `julia --startup-file=no test/runtests.jl`
- `julia +1.12 --startup-file=no test/runtests.jl`
- `python -m unittest discover -s tests`
