### PR TITLE
Add Julia notebook for canonical QUBO starter problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python
+.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-canonical-problems-julia
 
 PYTHON ?= python3
 UV ?= uv
@@ -14,6 +14,7 @@ GAMA_PYTHON_NOTEBOOK ?= notebooks_py/3-GAMA_python.ipynb
 PORTABLE_PYTHON_NOTEBOOKS ?= $(QUBO_PYTHON_NOTEBOOK) $(GAMA_PYTHON_NOTEBOOK)
 DWAVE_PYTHON_NOTEBOOK ?= notebooks_py/4-DWAVE_python.ipynb
 BENCHMARKING_PYTHON_NOTEBOOK ?= notebooks_py/5-Benchmarking_python.ipynb
+CANONICAL_PROBLEMS_JULIA_NOTEBOOK ?= notebooks_jl/7-CanonicalProblems.ipynb
 NOTEBOOKS ?= $(PORTABLE_PYTHON_NOTEBOOKS)
 NOTEBOOK_FILES ?= notebooks_jl/*.ipynb notebooks_py/*.ipynb
 
@@ -66,3 +67,6 @@ verify-gama-python:
 
 verify-benchmarking-python:
 	$(MAKE) verify-notebooks UV_GROUP_FLAGS="$(BENCHMARKING_UV_GROUP_FLAGS)" NOTEBOOKS="$(BENCHMARKING_PYTHON_NOTEBOOK)"
+
+verify-canonical-problems-julia:
+	$(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(CANONICAL_PROBLEMS_JULIA_NOTEBOOK)"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ long benchmark runs.
 | D-Wave | [notebooks_jl/4-DWave.ipynb](notebooks_jl/4-DWave.ipynb) | [notebooks_py/4-DWAVE_python.ipynb](notebooks_py/4-DWAVE_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; quantum annealer cells require D-Wave solver access. The Python D-Wave notebook requires a user-managed Ocean install and is not part of the locked Python verification environment. |
 | Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; benchmark runs are long-running and generate artifacts. |
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
+| Canonical QUBO starter problems | [notebooks_jl/7-CanonicalProblems.ipynb](notebooks_jl/7-CanonicalProblems.ipynb) | Not available | Credential-free Julia notebook covered by `make verify-canonical-problems-julia`; exhaustive checks validate number partitioning, Max-Cut, and minimum vertex cover. |
 
 ## Local verification
 
@@ -62,6 +63,7 @@ make test-python
 make test-julia
 make verify-qubo-python
 make verify-gama-python
+make verify-canonical-problems-julia
 ```
 
 The generic verifier can execute selected notebooks by overriding `NOTEBOOKS`

--- a/notebooks_jl/7-CanonicalProblems.ipynb
+++ b/notebooks_jl/7-CanonicalProblems.ipynb
@@ -1,0 +1,701 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "<a name=\"top\" id=\"top\"></a>\n",
+    "\n",
+    "<div align=\"center\">\n",
+    "  <h1>Three Canonical QUBO Starter Problems</h1>\n",
+    "  <p>Original Julia derivations and independent checks for number partitioning, Max-Cut, and minimum vertex cover.</p>\n",
+    "  <a href=\"https://colab.research.google.com/github/JuliaQUBO/QUBONotebooks/blob/main/notebooks_jl/7-CanonicalProblems.ipynb\" target=\"_parent\">\n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "  </a>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "### Local installation\n",
+    "\n",
+    "From the repository root, instantiate the shared Julia environment before opening this notebook:\n",
+    "\n",
+    "    julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
+    "\n",
+    "After that one-time environment step, every example below is credential-free and uses no network service."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "colab",
+   "metadata": {},
+   "source": [
+    "### Google Colab\n",
+    "\n",
+    "Open the badge above, select a Julia runtime, and run the setup cells. The bootstrap clones this repository only when Colab does not already have it, then activates the same checked-in notebook project used locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bootstrap",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
+    "\n",
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(Cmd([\"git\", \"clone\", \"--depth\", \"1\", \"https://github.com/JuliaQUBO/QUBONotebooks.git\", repo_dir]))\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"7-CanonicalProblems\")\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "activate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import Pkg\n",
+    "\n",
+    "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
+    "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
+    "if python_warning_filter ∉ python_warning_filters\n",
+    "    push!(python_warning_filters, python_warning_filter)\n",
+    "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
+    "end\n",
+    "Pkg.instantiate(; io = devnull)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "objectives",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. derive QUBOs for number partitioning, Max-Cut, and minimum vertex cover;\n",
+    "2. distinguish raw QUBO energy from the corresponding application score;\n",
+    "3. verify every binary state against an independently implemented scoring function; and\n",
+    "4. decode all exact optima and explain complementary or symmetric degeneracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prerequisites",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Prior notebooks:** Notebook 2 introduces JuMP and QUBO models; this notebook is also self-contained.\n",
+    "\n",
+    "**Mathematical background:** Binary variables, finite sums, and basic graph terminology.\n",
+    "\n",
+    "**Software:** Julia 1.10+ with the shared notebook project instantiated.\n",
+    "\n",
+    "**Accounts required:** None."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using JuMP\n",
+    "using QUBO\n",
+    "using Plots\n",
+    "\n",
+    "Plots.default(; size = (640, 420), legend = false)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "verification-strategy",
+   "metadata": {},
+   "source": [
+    "## Verification strategy\n",
+    "\n",
+    "Each section first defines an application-level score that does not inspect a JuMP model. We then enumerate all states, evaluate the actual expanded JuMP objective (including its constant), and compare the two values. Finally, QUBO.ExactSampler independently enumerates the model so that its best energy and complete optimal-state degeneracy can be compared with our application enumeration. Every JuMP model is a minimization model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shared-helpers",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function all_binary_states(n::Integer)\n",
+    "    states = Vector{Vector{Int}}()\n",
+    "    for state in Iterators.product(ntuple(_ -> (0, 1), n)...)\n",
+    "        push!(states, collect(state))\n",
+    "    end\n",
+    "    return states\n",
+    "end\n",
+    "\n",
+    "function evaluate_jump_objective(model::Model, variables, bits)\n",
+    "    assignment = Dict(variables[i] => Float64(bits[i]) for i in eachindex(variables))\n",
+    "    return JuMP.value(variable -> assignment[variable], JuMP.objective_function(model))\n",
+    "end\n",
+    "\n",
+    "function assert_all_states_match(model::Model, variables, analytic_objective; atol = 1e-9)\n",
+    "    @assert JuMP.objective_sense(model) == JuMP.MOI.MIN_SENSE\n",
+    "    states = all_binary_states(length(variables))\n",
+    "    for bits in states\n",
+    "        jump_value = evaluate_jump_objective(model, variables, bits)\n",
+    "        analytic_value = analytic_objective(bits)\n",
+    "        @assert isapprox(jump_value, analytic_value; atol = atol, rtol = 0)\n",
+    "    end\n",
+    "    return states\n",
+    "end\n",
+    "\n",
+    "function exact_sampler_optima!(model::Model, variables; atol = 1e-9)\n",
+    "    set_optimizer(model, QUBO.ExactSampler.Optimizer)\n",
+    "    optimize!(model)\n",
+    "    @assert termination_status(model) in (JuMP.MOI.OPTIMAL, JuMP.MOI.LOCALLY_SOLVED)\n",
+    "\n",
+    "    energies = [objective_value(model; result = result) for result in 1:result_count(model)]\n",
+    "    best_energy = minimum(energies)\n",
+    "    optima = [\n",
+    "        round.(Int, value.(variables; result = result))\n",
+    "        for result in eachindex(energies)\n",
+    "        if isapprox(energies[result], best_energy; atol = atol, rtol = 0)\n",
+    "    ]\n",
+    "    return best_energy, optima\n",
+    "end\n",
+    "\n",
+    "same_states(left, right) = Set(Tuple.(left)) == Set(Tuple.(right))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "partition-heading",
+   "metadata": {},
+   "source": [
+    "## Number partitioning\n",
+    "\n",
+    "Given positive weights $a_1,\\ldots,a_n$, divide them into two groups whose sums are as close as possible. Let $x_i=0$ place item $i$ in group A and $x_i=1$ place it in group B. We use the explicit spin/bit convention\n",
+    "\n",
+    "$$s_i = 1 - 2x_i,$$\n",
+    "\n",
+    "so the signed imbalance is\n",
+    "\n",
+    "$$I(x)=\\sum_i a_i s_i=A-2\\sum_i a_i x_i,\\qquad A=\\sum_i a_i.$$\n",
+    "\n",
+    "Minimizing its square produces the QUBO\n",
+    "\n",
+    "$$E_{\\mathrm{NP}}(x)=A^2+\\sum_i(4a_i^2-4Aa_i)x_i+8\\sum_{i<j}a_i a_jx_ix_j.$$\n",
+    "\n",
+    "The raw energy is the squared signed imbalance; the application score reported below is the absolute imbalance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "partition-application",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partition_weights = [1, 3, 4, 8]\n",
+    "\n",
+    "partition_signed_imbalance(weights, bits) =\n",
+    "    sum(weights[i] * (1 - 2 * bits[i]) for i in eachindex(weights))\n",
+    "\n",
+    "partition_imbalance(weights, bits) = abs(partition_signed_imbalance(weights, bits))\n",
+    "partition_energy(weights, bits) = partition_signed_imbalance(weights, bits)^2\n",
+    "\n",
+    "function decode_partition(weights, bits)\n",
+    "    group_a = weights[findall(==(0), bits)]\n",
+    "    group_b = weights[findall(==(1), bits)]\n",
+    "    return group_a, group_b\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "partition-model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partition_model = Model()\n",
+    "@variable(partition_model, partition_x[1:length(partition_weights)], Bin)\n",
+    "@objective(\n",
+    "    partition_model,\n",
+    "    Min,\n",
+    "    (sum(partition_weights[i] * (1 - 2 * partition_x[i]) for i in eachindex(partition_weights)))^2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "partition-check",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partition_states = assert_all_states_match(\n",
+    "    partition_model,\n",
+    "    partition_x,\n",
+    "    bits -> partition_energy(partition_weights, bits),\n",
+    ")\n",
+    "partition_energies = [partition_energy(partition_weights, bits) for bits in partition_states]\n",
+    "partition_best_energy = minimum(partition_energies)\n",
+    "partition_optima = partition_states[findall(==(partition_best_energy), partition_energies)]\n",
+    "\n",
+    "partition_exact_energy, partition_exact_optima = exact_sampler_optima!(partition_model, partition_x)\n",
+    "@assert partition_best_energy == 0\n",
+    "@assert isapprox(partition_exact_energy, partition_best_energy; atol = 1e-9)\n",
+    "@assert same_states(partition_exact_optima, partition_optima)\n",
+    "@assert length(partition_optima) == 2\n",
+    "@assert all(partition_imbalance(partition_weights, bits) == 0 for bits in partition_optima)\n",
+    "\n",
+    "for bits in partition_optima\n",
+    "    group_a, group_b = decode_partition(partition_weights, bits)\n",
+    "    println(\"x=$bits: A=$group_a, B=$group_b, imbalance=$(partition_imbalance(partition_weights, bits)), raw energy=$(partition_energy(partition_weights, bits))\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "partition-interpretation",
+   "metadata": {},
+   "source": [
+    "The two optimal bit strings are complements: one names $\\{1,3,4\\}$ as group A and $\\{8\\}$ as group B, while the other swaps the labels. They represent the same unlabeled partition, each with application imbalance 0 and raw QUBO energy 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "maxcut-heading",
+   "metadata": {},
+   "source": [
+    "## Max-Cut\n",
+    "\n",
+    "Let $x_i\\in\\{0,1\\}$ label the side of a cut containing vertex $i$. For an edge $(i,j)$, the expression\n",
+    "\n",
+    "$$x_i+x_j-2x_ix_j$$\n",
+    "\n",
+    "is 1 exactly when the endpoints are separated. Thus the cut weight is\n",
+    "\n",
+    "$$C(x)=\\sum_{(i,j)\\in E}w_{ij}(x_i+x_j-2x_ix_j).$$\n",
+    "\n",
+    "Max-Cut maximizes $C$. QUBO solvers minimize, so our raw QUBO energy is explicitly $E_{\\mathrm{MC}}(x)=-C(x)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "maxcut-application",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted_edges = [\n",
+    "    (1, 2, 2),\n",
+    "    (1, 3, 1),\n",
+    "    (2, 3, 2),\n",
+    "    (2, 4, 1),\n",
+    "    (3, 4, 3),\n",
+    "]\n",
+    "\n",
+    "maxcut_weight(edges, bits) =\n",
+    "    sum(bits[i] == bits[j] ? 0 : weight for (i, j, weight) in edges)\n",
+    "\n",
+    "maxcut_energy(edges, bits) = -maxcut_weight(edges, bits)\n",
+    "\n",
+    "function decode_cut(bits)\n",
+    "    side_zero = findall(==(0), bits)\n",
+    "    side_one = findall(==(1), bits)\n",
+    "    return side_zero, side_one\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "maxcut-model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maxcut_model = Model()\n",
+    "@variable(maxcut_model, maxcut_x[1:4], Bin)\n",
+    "@objective(\n",
+    "    maxcut_model,\n",
+    "    Min,\n",
+    "    -sum(\n",
+    "        weight * (maxcut_x[i] + maxcut_x[j] - 2 * maxcut_x[i] * maxcut_x[j])\n",
+    "        for (i, j, weight) in weighted_edges\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "maxcut-check",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maxcut_states = assert_all_states_match(\n",
+    "    maxcut_model,\n",
+    "    maxcut_x,\n",
+    "    bits -> maxcut_energy(weighted_edges, bits),\n",
+    ")\n",
+    "maxcut_energies = [maxcut_energy(weighted_edges, bits) for bits in maxcut_states]\n",
+    "maxcut_best_energy = minimum(maxcut_energies)\n",
+    "maxcut_optima = maxcut_states[findall(==(maxcut_best_energy), maxcut_energies)]\n",
+    "\n",
+    "maxcut_exact_energy, maxcut_exact_optima = exact_sampler_optima!(maxcut_model, maxcut_x)\n",
+    "@assert maxcut_best_energy == -7\n",
+    "@assert isapprox(maxcut_exact_energy, maxcut_best_energy; atol = 1e-9)\n",
+    "@assert same_states(maxcut_exact_optima, maxcut_optima)\n",
+    "@assert length(maxcut_optima) == 4\n",
+    "@assert all(maxcut_weight(weighted_edges, bits) == 7 for bits in maxcut_optima)\n",
+    "\n",
+    "for bits in maxcut_optima\n",
+    "    side_zero, side_one = decode_cut(bits)\n",
+    "    println(\"x=$bits: S0=$side_zero, S1=$side_one, cut weight=$(maxcut_weight(weighted_edges, bits)), raw energy=$(maxcut_energy(weighted_edges, bits))\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "maxcut-symmetry",
+   "metadata": {},
+   "source": [
+    "There are four optimal labeled bit strings. Complementing every bit swaps the two side labels without changing the cut, so the four strings form two complementary pairs. The application optimum is a cut weight of 7; the corresponding minimized QUBO energy is -7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "maxcut-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_positions = Dict(\n",
+    "    1 => (-1.0, 1.0),\n",
+    "    2 => (1.0, 1.0),\n",
+    "    3 => (-1.0, -1.0),\n",
+    "    4 => (1.0, -1.0),\n",
+    ")\n",
+    "representative_cut = first(maxcut_optima)\n",
+    "cut_plot = plot(; xlims = (-1.35, 1.35), ylims = (-1.35, 1.35), aspect_ratio = :equal, framestyle = :none, title = \"A deterministic maximum cut\")\n",
+    "\n",
+    "for (i, j, weight) in weighted_edges\n",
+    "    x_coordinates = [fixed_positions[i][1], fixed_positions[j][1]]\n",
+    "    y_coordinates = [fixed_positions[i][2], fixed_positions[j][2]]\n",
+    "    plot!(cut_plot, x_coordinates, y_coordinates; color = :gray65, linewidth = 0.8 + 0.7 * weight)\n",
+    "    annotate!(cut_plot, sum(x_coordinates) / 2, sum(y_coordinates) / 2, text(string(weight), 8, :black))\n",
+    "end\n",
+    "\n",
+    "node_x = [fixed_positions[i][1] for i in 1:4]\n",
+    "node_y = [fixed_positions[i][2] for i in 1:4]\n",
+    "node_colors = [bit == 0 ? :steelblue : :darkorange for bit in representative_cut]\n",
+    "scatter!(cut_plot, node_x, node_y; markersize = 18, markercolor = node_colors, markerstrokecolor = :black, series_annotations = string.(1:4))\n",
+    "cut_plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cover-heading",
+   "metadata": {},
+   "source": [
+    "## Minimum vertex cover\n",
+    "\n",
+    "A vertex cover selects vertices so every edge has at least one selected endpoint. With $x_i=1$ meaning selected, edge $(i,j)$ is uncovered exactly when $(1-x_i)(1-x_j)=1$. The penalized QUBO is\n",
+    "\n",
+    "$$E_{\\mathrm{VC}}(x)=\\sum_i x_i+P\\sum_{(i,j)\\in E}(1-x_i)(1-x_j).$$\n",
+    "\n",
+    "For this unweighted objective, $P=2$ is sufficient: if an edge is uncovered, selecting either endpoint increases the cover size by at most 1 and removes at least one penalty of 2. Therefore repairing an uncovered edge strictly reduces the objective; no infeasible state can be optimal. This is a proof-based choice, not a trial-and-error parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cover-application",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cover_edges = [(1, 2), (1, 3), (2, 3), (3, 4)]\n",
+    "cover_penalty = 2\n",
+    "\n",
+    "uncovered_cover_edges(edges, bits) =\n",
+    "    [(i, j) for (i, j) in edges if bits[i] == 0 && bits[j] == 0]\n",
+    "\n",
+    "cover_size(bits) = sum(bits)\n",
+    "cover_energy(edges, penalty, bits) =\n",
+    "    cover_size(bits) + penalty * length(uncovered_cover_edges(edges, bits))\n",
+    "\n",
+    "selected_vertices(bits) = findall(==(1), bits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cover-model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cover_model = Model()\n",
+    "@variable(cover_model, cover_x[1:4], Bin)\n",
+    "@objective(\n",
+    "    cover_model,\n",
+    "    Min,\n",
+    "    sum(cover_x) + cover_penalty * sum((1 - cover_x[i]) * (1 - cover_x[j]) for (i, j) in cover_edges),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cover-check",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cover_states = assert_all_states_match(\n",
+    "    cover_model,\n",
+    "    cover_x,\n",
+    "    bits -> cover_energy(cover_edges, cover_penalty, bits),\n",
+    ")\n",
+    "cover_energies = [cover_energy(cover_edges, cover_penalty, bits) for bits in cover_states]\n",
+    "cover_best_energy = minimum(cover_energies)\n",
+    "cover_optima = cover_states[findall(==(cover_best_energy), cover_energies)]\n",
+    "\n",
+    "cover_exact_energy, cover_exact_optima = exact_sampler_optima!(cover_model, cover_x)\n",
+    "@assert cover_best_energy == 2\n",
+    "@assert isapprox(cover_exact_energy, cover_best_energy; atol = 1e-9)\n",
+    "@assert same_states(cover_exact_optima, cover_optima)\n",
+    "@assert length(cover_optima) == 2\n",
+    "@assert all(isempty(uncovered_cover_edges(cover_edges, bits)) for bits in cover_optima)\n",
+    "@assert all(cover_size(bits) == 2 for bits in cover_optima)\n",
+    "\n",
+    "for bits in cover_optima\n",
+    "    println(\"x=$bits: selected=$(selected_vertices(bits)), uncovered=$(uncovered_cover_edges(cover_edges, bits)), raw energy=$(cover_energy(cover_edges, cover_penalty, bits))\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cover-interpretation",
+   "metadata": {},
+   "source": [
+    "The two minimum covers are $\\{1,3\\}$ and $\\{2,3\\}$. Every edge is checked directly, both covers have application size 2, and their raw penalized energy is also 2 because no penalty remains."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "practice",
+   "metadata": {},
+   "source": [
+    "## Practice checkpoints\n",
+    "\n",
+    "1. Change the partition weights to $[1,2,3,7]$. Before running the model, predict the minimum absolute imbalance and whether complement symmetry still doubles the labeled degeneracy.\n",
+    "2. Add edge $(1,4)$ with weight 2 to the Max-Cut instance. Recompute the direct cut scores and explain any change in degeneracy.\n",
+    "3. Replace $P=2$ by $P=1$ in the vertex-cover model. Find an infeasible state tied with a feasible optimum and explain why the strict inequality $P>1$ matters.\n",
+    "\n",
+    "For each change, rerun the all-state assertion before trusting the solver output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "exercise-partition",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE 1: Predict the best imbalance and labeled degeneracy for [1, 2, 3, 7].\n",
+    "# Then use all_binary_states and partition_imbalance to check your prediction.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solution-partition",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "practice_partition_weights = [1, 2, 3, 7]\n",
+    "practice_partition_states = all_binary_states(length(practice_partition_weights))\n",
+    "practice_partition_scores = [partition_imbalance(practice_partition_weights, bits) for bits in practice_partition_states]\n",
+    "practice_partition_best = minimum(practice_partition_scores)\n",
+    "practice_partition_optima = practice_partition_states[findall(==(practice_partition_best), practice_partition_scores)]\n",
+    "@assert practice_partition_best == 1\n",
+    "@assert length(practice_partition_optima) == 2\n",
+    "println(\"Best imbalance: $practice_partition_best; labeled optima: $practice_partition_optima\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "exercise-maxcut",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE 2: Add weighted edge (1, 4, 2), then recompute the best cut weight and degeneracy.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solution-maxcut",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "practice_weighted_edges = [weighted_edges; (1, 4, 2)]\n",
+    "practice_maxcut_states = all_binary_states(4)\n",
+    "practice_maxcut_scores = [maxcut_weight(practice_weighted_edges, bits) for bits in practice_maxcut_states]\n",
+    "practice_maxcut_best = maximum(practice_maxcut_scores)\n",
+    "practice_maxcut_optima = practice_maxcut_states[findall(==(practice_maxcut_best), practice_maxcut_scores)]\n",
+    "println(\"Best cut weight: $practice_maxcut_best; labeled optima: $practice_maxcut_optima\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "exercise-cover",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE 3: Set the cover penalty to 1 and find an infeasible state tied at the best energy.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solution-cover",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "weak_cover_penalty = 1\n",
+    "weak_cover_states = all_binary_states(4)\n",
+    "weak_cover_energies = [cover_energy(cover_edges, weak_cover_penalty, bits) for bits in weak_cover_states]\n",
+    "weak_cover_best = minimum(weak_cover_energies)\n",
+    "weak_cover_optima = weak_cover_states[findall(==(weak_cover_best), weak_cover_energies)]\n",
+    "weak_cover_infeasible_optima = [bits for bits in weak_cover_optima if !isempty(uncovered_cover_edges(cover_edges, bits))]\n",
+    "@assert !isempty(weak_cover_infeasible_optima)\n",
+    "println(\"With P=1, infeasible best-energy states include $weak_cover_infeasible_optima\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "**Learning objectives met:**\n",
+    "\n",
+    "- Number partitioning minimizes a squared signed imbalance; its raw energy is the square of the application imbalance.\n",
+    "- Max-Cut is a maximization problem, so its cut weight enters the minimized QUBO with a negative sign.\n",
+    "- Minimum vertex cover combines cardinality with an uncovered-edge penalty; a penalty strictly larger than one is sufficient here.\n",
+    "- Exhaustive application scoring, full JuMP-objective evaluation, and ExactSampler agree for every example.\n",
+    "- Complementary partition and cut bit strings can encode equivalent unlabeled solutions.\n",
+    "\n",
+    "**Next steps:** Use the practice checkpoints to change one instance at a time while keeping the all-state assertions green.\n",
+    "\n",
+    "**Further reading:**\n",
+    "\n",
+    "- The Five Starter Problems paper develops the application context for these formulations.\n",
+    "- The QUBO.jl documentation describes the public modeling and sampling interfaces used here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "references",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. A. Mazumder and W. P. Tayur, Five Starter Problems: Solving Quadratic Unconstrained Binary Optimization Models on Quantum Computers, INFORMS Transactions on Education (2025), https://doi.org/10.1287/educ.2025.0288.\n",
+    "2. Companion materials: https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers.\n",
+    "3. QUBO.jl public API and ExactSampler: https://github.com/JuliaQUBO/QUBO.jl.\n",
+    "\n",
+    "This notebook contains original Julia code, examples, prose, and figures. The companion repository is cited as context; no source cells, prose, saved output, or assets were copied from it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia",
+   "language": "julia",
+   "name": "julia"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks_jl/7-CanonicalProblems.ipynb
+++ b/notebooks_jl/7-CanonicalProblems.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "bootstrap",
    "metadata": {},
    "outputs": [],
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "activate",
    "metadata": {},
    "outputs": [],
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "imports",
    "metadata": {},
    "outputs": [],
@@ -168,10 +168,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "shared-helpers",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "same_states (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function all_binary_states(n::Integer)\n",
     "    states = Vector{Vector{Int}}()\n",
@@ -239,10 +250,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "partition-application",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "decode_partition (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "partition_weights = [1, 3, 4, 8]\n",
     "\n",
@@ -261,10 +283,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "partition-model",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$ 4 partition\\_x_{1}^2 + 24 partition\\_x_{2}\\times partition\\_x_{1} + 32 partition\\_x_{3}\\times partition\\_x_{1} + 64 partition\\_x_{4}\\times partition\\_x_{1} + 36 partition\\_x_{2}^2 + 96 partition\\_x_{3}\\times partition\\_x_{2} + 192 partition\\_x_{4}\\times partition\\_x_{2} + 64 partition\\_x_{3}^2 + 256 partition\\_x_{4}\\times partition\\_x_{3} + 256 partition\\_x_{4}^2 - 64 partition\\_x_{1} - 192 partition\\_x_{2} - 256 partition\\_x_{3} - 512 partition\\_x_{4} + 256 $"
+      ],
+      "text/plain": [
+       "4 partition_x[1]² + 24 partition_x[2]*partition_x[1] + 32 partition_x[3]*partition_x[1] + 64 partition_x[4]*partition_x[1] + 36 partition_x[2]² + 96 partition_x[3]*partition_x[2] + 192 partition_x[4]*partition_x[2] + 64 partition_x[3]² + 256 partition_x[4]*partition_x[3] + 256 partition_x[4]² - 64 partition_x[1] - 192 partition_x[2] - 256 partition_x[3] - 512 partition_x[4] + 256"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "partition_model = Model()\n",
     "@variable(partition_model, partition_x[1:length(partition_weights)], Bin)\n",
@@ -277,10 +313,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "partition-check",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x=[1, 1, 1, 0]: A=[8], B=[1, 3, 4], imbalance=0, raw energy=0\n",
+      "x=[0, 0, 0, 1]: A=[1, 3, 4], B=[8], imbalance=0, raw energy=0\n"
+     ]
+    }
+   ],
    "source": [
     "partition_states = assert_all_states_match(\n",
     "    partition_model,\n",
@@ -332,10 +377,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "maxcut-application",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "decode_cut (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "weighted_edges = [\n",
     "    (1, 2, 2),\n",
@@ -359,10 +415,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "maxcut-model",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$ 4 maxcut\\_x_{1}\\times maxcut\\_x_{2} + 2 maxcut\\_x_{1}\\times maxcut\\_x_{3} + 4 maxcut\\_x_{2}\\times maxcut\\_x_{3} + 2 maxcut\\_x_{2}\\times maxcut\\_x_{4} + 6 maxcut\\_x_{3}\\times maxcut\\_x_{4} - 3 maxcut\\_x_{1} - 5 maxcut\\_x_{2} - 6 maxcut\\_x_{3} - 4 maxcut\\_x_{4} $"
+      ],
+      "text/plain": [
+       "4 maxcut_x[1]*maxcut_x[2] + 2 maxcut_x[1]*maxcut_x[3] + 4 maxcut_x[2]*maxcut_x[3] + 2 maxcut_x[2]*maxcut_x[4] + 6 maxcut_x[3]*maxcut_x[4] - 3 maxcut_x[1] - 5 maxcut_x[2] - 6 maxcut_x[3] - 4 maxcut_x[4]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "maxcut_model = Model()\n",
     "@variable(maxcut_model, maxcut_x[1:4], Bin)\n",
@@ -378,10 +448,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "maxcut-check",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x=[1, 0, 1, 0]: S0=[2, 4], S1=[1, 3], cut weight=7, raw energy=-7\n",
+      "x=[0, 1, 1, 0]: S0=[1, 4], S1=[2, 3], cut weight=7, raw energy=-7\n",
+      "x=[1, 0, 0, 1]: S0=[2, 3], S1=[1, 4], cut weight=7, raw energy=-7\n",
+      "x=[0, 1, 0, 1]: S0=[1, 3], S1=[2, 4], cut weight=7, raw energy=-7\n"
+     ]
+    }
+   ],
    "source": [
     "maxcut_states = assert_all_states_match(\n",
     "    maxcut_model,\n",
@@ -415,10 +496,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "maxcut-plot",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoAAAAGkCAIAAAAuegPJAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3dd2ATdeP48U/TvVtaCh1QKLRl741MQRwgIiC4kCHi4kFFUB9FQRHFgQMnMtwIKkuqCIVKGWXPQoHuFlronnQnvz/u+8sTU5o2adJL0vfrL7neffJpWvvOXe4uNiqVSgAAgKalkHsCAAA0RwQY8lu7du28efNSUlLknogRLFiw4D//+Y++W9XU1MyZM2fJkiWNn8CpU6fmzJnz22+/NX4oc3D48OE5c+bs3LlT7okAxkeAYaBr167Z2dnZ2Ng8++yzjRxq3759a9asycrK0murrKysNWvW7N27t5GPblw//PDDDz/8oO9WNTU169ev16uap0+fXrNmzeXLl7WWJycnr1+//tixY/rOwTxduXJl/fr1p0+flnsi5mLDhg3ff/+93LOAcRBgGGjDhg01NTVCiB9//LGsrKzpJ5CUlDRv3rx169Y1/UPrMGzYsGHDhum7lUKhGDly5MCBAxu+SURExLx58w4ePKi13M/Pb+TIkR07dtR3DubJ399/5MiR7dq1k3si5mLBggULFy6UexYwDju5JwCLpFKpvvvuO3t7+wkTJmzZsmX79u3Tp0+Xe1JmYfv27QZsZWdnFxUVZZQJDBs2zFhDmYNx48aNGzdO7lkAJkGAYYjo6OiEhIQJEya8+OKLW7Zs2bBhQ8MDXF1dvWfPnri4OE9PzzFjxgQHB9e1Zl5e3t69e9PT052cnAYMGNCvXz/1l9LS0i5duiStc/LkSWlhQECAv7+/ep3r16/v3bs3MzPTw8Nj6NChXbt21Rw8Nzc3JSXF398/ICAgISFh//79+fn5Dz74oJeX16VLl7y9vUNCQq5du7Z79+7CwsKePXuOGjVK2rCysvKvv/5KTExs2bLl+PHjvb29NYc9e/asEKJnz57SP0tKSi5fvuzj49OuXbvMzMxdu3bl5eV16NDhrrvucnR0VG+lUqlOnTrl7OzcpUsX9UKlUnnkyJH4+Pjs7GxphMGDBzs5OQkhLly4kJGRIYRITU1Vf/vh4eFubm4FBQWJiYmtW7cODAzUnJhSqTx69OjZs2dv3rzp7+8/aNCg9u3b6/gxpaSk5ObmhoeHu7q6RkdHnz171tXVddy4cUFBQdIKycnJUVFRhYWFvXv3HjlypNbmKpXq7NmzFy5cuH79uqura+/evbX2769evXrjxo0WLVpoTSMzMzMjI8PT01PaiZd+TIGBga1bt5ZWSExMLCgo6Ny5s5OT0759+y5cuODh4XHXXXepV4iPj9+/f39JSUn//v2HDh2qOXhqampOTk5YWJi7u7vm8tOnT9va2vbo0UP6Z35+flJSkvQcxsfHR0VFVVRUDBo0qH///tIKJSUlf/75Z3p6etu2be+55x4XFxcdz6Tmc3Lq1KlTp04VFRW1atWqf//+4eHh0peKi4uvXLni6+ur9b+D+qeg/snW1NRUV1erf+hubm7qQWB5VID+HnvsMSHEr7/+qlKpOnXqpFAoUlNTG7JhSkqK+s+cEMLW1vbdd9998MEHhRBHjx5Vr6ZUKt955x2tv2tjxozJycmRVnj66adr/zIvW7ZM+mpVVdXChQvt7e01vzpt2rTS0lL1Q3z33XdCiNdff33BggU2NjbSOrt375bePZ06dernn3+uOcI999xTXl5++vRpzT+RLVu2PHv2rOY36O3t7eXlpf5ndHS0EGLGjBlffPGFg4ODesPQ0FDNZ6yiokII0alTJ80nSl1xNW9vb+mrYWFhtb/9Q4cOqVQq6Y3kRYsWac7q6NGjmmmXvPrqqzp+Uo8++qgQYtu2bcOHD1dv4ujoKP3QX3/9dVtbW/XyBx54oKamRr3t+fPnAwICtB5u0KBBV69eVa9z5coVd3d3Nze3S5cuqRfm5+e3b99eoVDs3r1bWrJhwwYhxJtvvqleZ9KkSUKIXbt2DRgwQD24i4tLRERETU3NwoULFYr/vbM2e/ZszW/qiSeeEEJERkZqfbPOzs4BAQHqf27atEl6Dl966SX174YQ4oknnlAqlbt3727RooV6YceOHdPT03U8k5KLFy9qvoKUzJkzR/qqdCrD3LlztbaaNWuWEGL//v0qlWrLli21f+jDhg2r96Fhtggw9FZcXOzm5ubt7V1eXq5SqZYvXy6EeOutt+rdsKKiolu3bkKIGTNmnDlzJiUl5dNPP3VxcZH+WGsG+I033hBChIWF/fTTTxcuXDh48OBDDz0k/bmR/tDHxcV9+umnQohRo0bt+f+SkpKkzR9//HEhRJ8+fbZs2RIXF7dv374777xTCDFt2jT1Q0gBbtu2bcuWLT/88MN//vln586dCQkJUoDbtGnj5ub2/vvvHzt2LCIionPnzkKIV155JTAw8OGHH96zZ8+RI0ekP459+/bV/B5vGeDg4GBXV9d33333yJEjkZGRY8aMEUKMHz9e85kR/w6wNOFnnnnm5MmTaWlpp06d+v777++9917pq4cOHZo5c6YQYuHChepvv6CgQHWrAJ85c8bFxUWhUPznP/85cuTIlStXIiMjX3755ddee03HD0sKcHBw8MCBA7dv337ixIkVK1bY2dm5u7uvWLHC29v7888/P378+JYtW6RXJN9995162wMHDowcOXLdunWHDx+Oj4/fu3fv5MmThRBDhgzRfIiNGzcKIXr06FFWViYtuf/++4UQS5YsUa9TV4CDg4OHDx/+xx9/HD9+/I033lAoFD4+PkuXLm3ZsuWaNWtOnDixefNm6XDI77//rt5WrwAHBwf7+vqqR5N+S9999113d/fnnntu//790dHRd999txBiypQpOp5JlUqVnJzs4+MjhJg5c+bBgwcTEhL++eefZcuWPf3009IKDQnwjRs39uzZ4+zs7Onpqf6hHz9+XPdDw5wRYOjtm2++EUI8+eST0j/T09NtbW3bt2+vVCp1byidMDV69GjNNb/88kvptbw6wImJiba2toGBgbm5uZqb33fffUKIP/74Q/pnTEyMEOLBBx/UepRDhw4JIbp37y69PpDU1NRIO0wnT56UlkgBtrGxOXz4sObm6vOHd+zYoV544sQJaeEjjzyiXqhUKqU90eTkZPXCWwZYCPHXX3+pFxYXF/v4+CgUipKSEmlJ7QA7OjqGhITU9UyqVKq33npLCLF27Vqt5bUDLJ0UtmrVKh2j1SYFODw8vKKiQr1QOvJhY2Nz5MgR9cI///xTCDFhwgQdoymVSumt3GPHjmkul15GzJ8/X6VSSa+ohg0bVlVVpV6hrgD36tVLczWp3HZ2dufPn1cvlDqq+RuiV4BtbW3PnDmjXqg+R13z9UFxcbGnp6e9vX1lZaWOb3/q1KlCiJdeeqmuFRoSYIm7u7uvr6+Ox4IF4Sxo6E36mzhjxgzpn0FBQSNGjEhOTt6/f7/uDbdt2yaEeOGFFzQP682aNUvaOVD7+eefa2pqnnnmGc0DfUKIp556SggRERGh+1Gkq4AWLVqk+SarQqF48sknhRB//fWX5srDhw8fPHhw7UFCQ0MnTJig/mffvn3d3NyEEM8//7x6oY2NjXR4Njk5WfeUunfvLu3RStzc3IYMGaJUKlNTU+vaxMvLKzs7OyEhQffI9UpPTz9w4IC/v//8+fMN2PzZZ5/VPHI+YsQIIcTQoUM139CVFup+EmxsbCZOnCiE0Lo+6rPPPuvSpcvq1auXLl26aNEiX1/fjRs32tnVf27KggULNFeT5jB27FjpEEvDJ6bD7bffrvkugPpQvObvgJubW9++fauqqq5evVrXOKWlpdu2bXNxcXnttdcMmwmsFSdhQT9XrlyJiYnp2LHjoEGD1AtnzJixb9++DRs21D4ZR9PFixeFxglKEkdHx86dO2teTiNd9Hny5MmXX35Zc828vDwhRL3365A2l07P0VyelpZWe3OtM7PUar/J2rJly5KSktDQUK2FQogbN27onlLt02RatWolbVj7rVnJ7Nmz33nnna5du44dO3bMmDFjxozRTEvDSSeFde/evSFVq03reZC+X60nwcXFxdXVVetJOHLkyIcffnj+/Pn09PSbN2+ql+fk5Giu5urqunnz5gEDBixbtszGxmbdunVa5441ZmIN/Ok08CF8fX1tbGx8fX21TruTHiUrK6uuk9ri4uKqqqo6d+4svYYD1Agw9LN+/XqVSuXn5/fee++pF5aUlAghfv/999WrV3t4eNS1rbSa9AdLk9aS/Px8IcSePXv27duntaa3t3e9ISkoKBBCbN26VfNkHPXmWgt9fX1vOUjt81qlDbWWSwuVSqXuKdU1mo4Nly9fHhQU9PXXX0dEREg7/eHh4Z988om+1+QUFRUJITRPDteLs7Oz5j+lQxe3/HZUGneV37Zt25QpU+zt7e+4445JkyZ5eXkJIc6cOfPLL79I145rCg0NDQkJiY2NDQkJ0TxOoJvWHG45MelJVhl6u/vaD2FjY2PAj7KRPwJYMQIMPVRXV0sHeA8fPnz48GGtr5aWlm7evFk6AeqW3Nzcbty4kZWV1aZNG83lWvfAki4R+fHHHzUPAjectJ+xb9++Pn361Luy5sFws6JQKJ5++umnn3766tWr+/bt27p1644dOyZMmHD8+PHaZ0fr4OnpKYS4du2ayWZ6C4sXL1apVNHR0errdoQQH3300S+//FJ75Zdffjk2NrZFixaJiYn//e9/P/jgA9NNTPpxa8WyqqqqsrLSdA8q/Qiky8bqIlW89qsT6TUrrBXvAUMPu3btysjIGDBgwJ5aPvvsMyHE+vXrdWwuHUTVuq1gWVmZdGharXfv3kII6VwqHaRrhKqrq7WWS5vXfn1goYKCgmbMmLF169bFixdXVVXt2LFDWi69NVv7T7YW6dk4d+5cVVWVqacquXnzZnx8fMeOHTXrK4Q4depU7ZUjIiI+/vjj0NDQ2NjY8PDwVatWGXYnkwaSrhXWOih9+fLlep/GxujSpYujo2NCQoK0K9zwiQkh4uLitJbY29vX/p2HhSLA0IN0+tXs2bPH1PLUU08FBQXFxMTU/pOhJp2q+uGHH2oeFVy3bp10zFnt0UcftbOzW7NmTVJSktYISqWytLRU+m/pzcL09HStdaQTRz/44AOttxuFENXV1eXl5fp8x/K45TylY5jS+dJCCOmqmNrfvpaAgIAxY8ZkZWWtWrXKBDO9BWdnZzc3t6ysLM0blF68eLH27u/Vq1cfe+wxR0fHTZs2+fv7b9682cnJadasWTrOTWukkJAQUetEvBUrVpjo4STOzs5Tp04tKytbunRpXesEBwfb2toeOnRIM9I7duyIjY3VWjMwMLCwsFBHy2FBCDAaKjc3NyIiwt7efsqUKbW/qlAopk2bJoSQLu+5pYceeqh3797R0dHTpk07cuTIxYsX33vvvUWLFmkdke7QocPbb7+dn58/aNCg999/Pyoq6vz583/88ceyZctCQ0N3794trdaqVau2bdsePXp03rx5q1evXrNmjbSPNWTIkPnz56empvbr12/16tUHDhw4c+bMtm3bXnnllbZt2547d86YT4pp5ObmBgYGPvfcc9u2bTt37lxsbOzatWuXLVtma2srXVArhOjbt6+Njc3nn3/+6quvfvXVV2vWrKnrbKPVq1e7u7u/8sorTzzxRFRU1IULF/76668XXnhB6xw3Y7GxsRk5cmRBQcHkyZMPHDhw+fLlDRs2jBkzpm3btpqrVVdXT58+PTc396OPPpJ203v06LFy5cr8/PxHH33URDt5d999t7u7+8aNG1988cXo6OitW7dOnDgxJiZG654tRrdy5cpWrVp99NFH06dP37Nnz4ULF3bv3v3aa69Jl0UJIZydnSdOnFhQUHDPPffs3LkzKirqjTfemD59eu17evfr10+lUk2aNGnVqlVr1qxRHxGBRZLzGihYFGkXSn0viNqk/rVq1UrzAk0t165d07yBkZ2d3ccff1z7TlgqlWrdunXSqcKaunfvrr6QV6VSHThwQPM0ZvWdsJRK5XvvvSe996ZmY2PTv39/9TW70guFN954Q2uG6jthaS3v0KGDEKK6ulpz4auvviqE+Omnn9RL6roTltZoWhekal0HnJeXV/sOnb6+vps2bdIc5LPPPtN8inTcCev06dO9evXSHM3W1lb3vVOk64Cjo6M1F0ofC/jMM89orax1cWpaWprW6eWPPfbYt99+KzQuopXyX/sWFtJlvurV6roO+PTp05pbSff0ePnll7VGE0K0a9dOc8m2bds0z0YOCwu7ePHiLa8Dlt7J1qRQKIKDg7UWSr+9WleT15aQkHDbbbdp/UJKF0BLMjIyNG8S5+TktHbt2trXAWdmZo4bN059KiJ3wrJoNipDTxFEc5OVlVVSUuLt7a11GYYm6aBxmzZtdOxSKJXKQ4cOxcXFubm5jRo1yt/fXxo5MDBQ88pdIURFRcWRI0cSExOVSmXr1q27du16yys9Kioqrl+/XlNTozW30tLSmJiY5ORkW1tbf3//nj17at4fsaSkJCsrq/a3U1FRce3aNVdXV638p6enV1VVSccw1fLy8goKCvz8/NR/06VnQL1aeXl5RkaGm5ubn5+f5oY5OTlFRUX+/v7q04zj4+MdHBw0u5uUlCTdS9nJyal9+/b9+/fXen4kxcXF2dnZQoiAgAAnJ6fS0tKMjIwWLVpoXV2tUqlOnz59/vz5iooKf3//AQMG1H59o0n6oUhjqhfevHnz+vXrHh4eWmePp6Sk2NjYaE6+uro6JiYmPj7e3t5+8ODBHTt21HrCU1JSlEql1vhCiLKysszMTIVCIX0CUnFx8fXr1318fNQXhd+4caO0tDQoKEjzAmVpcC8vL61rx5OSkuzs7LR2vnNyciIjIwsLC0NCQkaNGmVnZ5ecnCzFVVqhtLT0xo0bDRztlk9UXWJjY0+dOlVWVta6des+ffpoHfuprq6OiopKSkry8PAYO3asr69vdnZ2cXFx7cFrampu3LhRXl7u5ORU+66fsBQEGAAAGfAeMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAwIMAAAMiDAAADIgAADACADAgwAgAzs5J4ArFlFRUVGRkZBQYG9vb2Xl1dAQIBCwWs+4P+oVCrpf5CKigrpfxAnJye5J4WmQ4BhZFVVVX/99ecfv/5w9EiMjbIiyEvh6qASQpFbqswsUnl6eY+4fdyUB2f269dP7pkC8jh37tz3P238e3dkTm6ek7u3o5unSiWU1RVlhbkKUTOg/4DpUydNGD/e0dFR7pnCtGxUKpXcc4CVKCkpWf3R+9+t+2J0+6opnQoHBwtne+11skvEvgSbn+NaZFZ6LnptxZSpD9jY2MgxWUAGO3bseG3p8lKlnWvo0BYhPR3dvLVWUNZUF6ZfKk48Vph8+rFHHn5p0UIvLy9ZpoomQIBhHNu3bfnvwqdndCt8emC5ewNeuCflireiPZOrg7/+bnN4eLjpJwjIKSUl5eHHZmeVKVoNnurqG1Tv+jVVFTdO784/H7lyxVsPP/RgE8wQTY8Ao7FqampeeHbu5cNb199XEOCh37aHUsSTO1sseefTB6Y/bJrZAfLb/scfT89/PmDkzBYdeuu1YWVpYdrurwd2bf/tujUODg4mmh7kQoDRKJWVldMn3RVec3TFmFLDjiXnl4n7N3pNnvvfZ59bZOzZAfJbt37D0nc/6nj/Sw6uBh1MVqmuxfzudTN1z64IZ2dnY88OciLAMJxKpXp46r1dKqNeG1HamHHKq8Vd33s+t3zdxEmTjTU3wBxs/u23ha8uD5v6mp1jo9qZcXRHB8f8rb9t4pwJa8I1ITDc+++86ZG9v5H1FUI42YnNDxQuWTjv3LlzRpkYYA7i4uKeX/Tf0PtfbmR9hRABA++Nu35z2VtvG2ViMBPsAcNAsbGxMyeNOPh4npORrmU7nyke3dn26NkrXH0BK1BTU9Oj7wD3QY96BoYaZUBlTfWljW9s/vbLwYMHG2VAyI49YBhowbxHV99Vf32LykVSrkjKFfW+0uvuL+7rkPPJh+8aa4aAjL76eo3Sq53u+lbdLM5LPp9xZm/Gmb2FV6/o3h1S2Nq1HTt3zrxn2GuyGuwBwxDR0dGrFk7aNj2vrhV2XBCbz4oT6SI+RyhVQghRsVI42NYzbEmF6L/G98SFFFdXV6POF2hSVVVVHcK7dpy2zN7l1hcG5KfEJv6zMT8lVqWsUS908Qnocu/8Fu276xg5+c/P3n/5yYkTJxp5xpADe8AwxBerli8cWGd9hRC/nRM/nRKJuaJbaz2GdXMUkzuXbd70S2PnB8hqZ0SES1CXuuorhMhLOZ+XdNYzKCx0zGM9Hnip84RnvNt1u5mbceqHN4quxesYuWXf8StXfWKCKUMG7AFDb6WlpQO6to19Nk/H+ZjRScLBVvQMEM72wuZFIRq2ByyEuJQlFsT0+Tv6pNGmi1oqKyu5qNSk7pxwX0HAcM+gOu8wk5t4xs7RxTMo7H+LVKpzv753PfZAy04Dez+0RMfgF79bfCrmn5YtWxpxwpAFe8DQ28GDB0eEKHVfDTE8RAy61a0o69XJT6SnpZSXlxs8PdQlNzd34sSJ7u7uXl5enTt33r17t9wzsk4qlers2bMegWE61vHp0Otf9RVC2Ni0HTRBCFGckah7fPfgHvuioho9TciPAENvx2MODG5dYLrx+wQpzp8/b7rxm63Kysq77rorPT395s2bCxcunDx5clFRkdyTskKJiYmuPgEGXLCrsHMQQijs6nnd6uQf9k/0IQMnB3NCgKG3KxdOhZvy6Fe4V+mVK1dM+ADNlb+//5NPPind3H/mzJnl5eXJyclyT8oKXblyxdE7wIANr5+PFkJ4t9N1EpYQwtU3KDbukiEzg5nh4wiht5zs7Ja6jq41VkunsuPHjrZr186Ej9HsHThwwMPDIy8v79Ah9qWMLCYmRmmv92n8+SmxqTHbFPYO7YdP1b2mg6tnZk6OobODGSHA0Ft5Rbmxbr5xS872IudGZlpamgkfo3m7cePGypUrZ8+eff36dbnnYoWuX78uFPqd/lBemHP+tw9USmWXCfNcWvjrXllh51BeVtaICcJcEGDozcXF5WaVCccvrbRpExrSpUsXEz5GM5aZmblw4cL58+dPnsydt00iOTn5YOrlhq9fWVpw8vsl5UU5HUc/Eth3XL3r11SVu7q5NWKCMBcEGHpr3Togs0h08DHV+JllLn369uvZs6epHqAZu3r16uTJk1944YUXX3xR7rlYrezs7J92n2jgypWlhSfW/7c0O73dbZNDRk5vyCYVxfmtWrVqxARhLjgJC3rr1GNAXJYJf3Pi8lw6depkuvGbrdzc3NGjR3fr1q1Xr16RkZGRkZG5ublyT8oKderUqSz3akPWrC4vPfXDGyXZaW0H3xt2x6wGjl+and6zW9dGTBDmgj1g6G3wbcPX7PSeK0zyt1ulErGZSo4/m0JOTk5wcHBpaenKlSulJStWrPDxMdmhjOYqKCiosiRfWVOtsNX1B7a6vPTEd68VZSQE9h3X6c65DR+/8vql0Y/OafQ0IT8CDL31799/dqqoqhH2Dbizlb6Oponu3XvY2ppg6GYvPDx8z549cs+iWbht6JCE5HM+HfvUtUJ1eenJ75cUXYsP7DO2y73PioZfNKxSFSSfGz58uHEmClkRYOjNwcFh9Jixf17aNLFrnfcx/SdRvB35ryV3fSMUNkIIsXiUGFv3VUzfnfd8eMF8Y00VkMWTj896YvFyHQFO/Gdj4dUrNgpFWUHWqe+1bzzZd8ZbdSU5P/VC71493d3djTldyIQAwxDzX1zyxJTdE7vW+XkM14tF5L9vKb8v4f/+49G+dQ57vVgcvOq6evwEo0wSkMuIESMUZc+X5V939r71p5EoqyuFECqlMi/pbO2vqoSoa4845/i2T9d8ZLSJQlZ8GAMM9MjU8fe57prSvab+VRtszjbPUXM/fmTGTCOOCchix44dzy9b1fG+RUYcMy/xtOvVA/9E/m3EMSEjAgwDZWRkjBnSY/+s3JZGuiLxz0uKDy722HvwlAE30QXM0O3j7i7w6e3beYhRRqsqK77085IDe3d16NDBKANCdlyGBAMFBAS89cEXj2zxqjLGPnDcDfFSlN/Pv/9FfWE1Nv7wbdaRzaU5DbokSTeVsiZxx6qP3ltBfa0JAYbhJk95YOi982Zt9ahWNmqcjCLx4O8tvtsc0br1rd8wAyyRn5/f6lXvX/p1RVlBVmPGUSmVKbvXPDhx3LQH6rlNNCwLAUajvP7Wu+2Gz578i2dxhYEjHEsTd/zg+8FXG/v0qfOUUcASJSQklJWVPTN35qVNbxZl1vMpv3WpLi+N3/LuuP5h7yx/07jTg+x4DxhGsP6brz5999Uv7s4b0k6PrZQqseaY/dfnAzbv2BMaGmqqyQFySEhIOH78uBCiTZs23t7e902Z7tRxqH+/u20UelzjXpSZmPb3l8uXvDJr5gyTzRSyIcAwjosXLz4z56EAkfrasILO9d2nVqUSf12yeeugd59hd6/44DNPT88mmSPQRDTrO3ToUBsbm9LS0sWvvLot4m+/gVNadhpY77kON/Mys45ucSjP/mH9N7169WqSWaOpEWAYjUql+vPPiPffekVZnHl/eOHokOrOfv+6W1ZxhTh5VexJdt1+ybFP/yEvL13JLSdhfWrXV/NLr7/5dtT+aO+O/V3adPcMDLVz+t8nB6uUNaU51wpTz5cmHXNzsFn66suTJk1SKHij0GoRYBhfUr7DIogAABZ3SURBVFLSzh1bo/fsuHQ5vqaqUlVToRQKe3sHZxe3nr16jb578vjxE9jrhVXSUV+1kpKSiIiIHX/+ffLkqZKS0orKSqFQ2CkU9na2HTp2vGvs6Psm3hsWVvft4mAtCDBMbsuWLUFBQQMGDJB7IoBpNaS+tZ05c+bSpUvTpzfoswhhTTi4AZPjkxXQHBhWXwn/jzRPBBgAGqsx9UWzRYABoFGoLwxDgAHAcNQXBiPAAGAg6ovGIMAAYAjqi0YiwACgN+qLxiPAAKAf6gujIMAAoAfqC2MhwADQUNQXRkSAAaBBqC+MiwADQP2oL4yOAANAPagvTIEAA4Au1BcmQoABoE7UF6ZDgAHg1qgvTIoAA8AtUF+YGgEGAG3UF02AAAPAv1BfNA0CDAD/Q33RZAgwAPwf6oumRIABQAjqiyZHgAGA+kIGBBhAc0d9IQsCDKBZo76QCwEG0HxRX8iIAANopqgv5EWAATRH1BeyI8AAmh3qC3NAgAE0L9QXZoIAA2hGqC/MBwEG0FxQX5gVAgygWaC+MDcEGID1o74wQwQYgJWjvjBPBBiANaO+MFsEGIDVor4wZwQYgHWivjBzBBiAFaK+MH8EGIC1ob6wCAQYgFWhvrAUBBiA9aC+sCAEGICVoL6wLAQYgDWgvrA4BBiAxaO+sEQEGIBlo76wUAQYgAWjvrBcBBiApaK+sGgEGIBFor6wdAQYgOWhvrACBBiAhaG+sA4EGIAlob6wGgQYgMWgvrAmBBiAZaC+sDIEGIAFoL6wPgQYgLmjvrBKBBiAWaO+sFYEGID5or6wYgQYgJmivrBuBBiAOaK+sHoEGIDZob5oDggwAPNCfdFMEGAAZoT6ovkgwADMBfVFs0KAAZgF6ovmhgADkB/1RTNEgAHIjPqieSLAAOREfdFsEWAAsqG+aM4IMAB5UF80cwQYgAyoL0CAATQ16gsIAgygiVFfQEKAATQd6guoEWAATYT6ApoIMICmQH0BLQQYgMlRX6A2AgzAtKgvcEsEGIAJUV+gLgQYgKlQX0AHAgzAJKgvoBsBBmB81BeoFwEGYGTUF2gIAgzAmKgv0EAEGIDRUF+g4QgwAOOgvoBeCDAAI6C+gL4IMIDGor6AAQgwgEahvoBhCDAAw1FfwGAEGICBqC/QGAQYgCGoL9BIBBiA3qgv0HgEGIB+qC9gFAQYgB6oL2AsBBhAQ1FfwIgIMIAGob6AcRFgAPWjvoDREWAA9aC+gCkQYAC6UF/ARAgwgDpRX8B0CDCAW6O+gEkRYAC3QH0BUyPAALRRX6AJEGAA/0J9gaZBgAH8D/UFmgwBBvB/qC/QlAgwACGoL9DkCDAA6gvIgAADzR31BWRBgIFmjfoCcrGTewKwcoWFhYmJiXZ2/KaZheLi4kOHDuXn53fv3r1bt27UV3ZVVVWJiYnp6elyTwQysFGpVHLPAVZr1qxZP//8s0KhmDZt2rfffiv3dJq7lJSUHj16DBgwICAgYNeuXePHjx87dqygvvLZvn379OnTHRwcnJycbty4Ifd00NQIMEwoOTk5ICDg7rvvbtOmDQGWXXFxcXFxcUBAgBAiMjJy7Nixn376ae/evamvXHJycoQQmzZtevPNNwlwM8SBQZhQ+/bt5Z4C/sfd3d3d3V0IkZCQkJ6erlAofH19qa+MfH195Z4C5MRJWEDzIr3vu3379u7du0+bNo36AnJhDxhoRqT6Hjx48PDhwzExMQoFL8EB2RBgoLmQ6nv06NFNmzbt37+/Q4cOcs8IaNYIMNAsSPU9fvz4d999FxkZ2bVrV7lnBDR3tkuXLpV7DrBaW7Zs+fjjjw8fPpyVlRUbG+vi4hISEiL3pJojqb43btx4++23e/funZ6evnPnzp07d4aEhPj5+ck9u+YrLS1t8eLF+/btS01NTUtLu3Dhwm233Sb3pNB02AOGCQUGBvbt29fOzs7T07Ndu3b8rZeF+m4bHTt2XL16teZZVx4eHvLNC8LFxaVv375+fn5du3aV/kPuGaFJcR0wTG779u3+/v4DBgyQeyLNEfe6Mn9nzpyJj4+fOnWq3BNBU+McSMBqUV/AnBFgwDpRX8DMEWDAClFfwPwRYMDaUF/AIhBgwKpQX8BSEGDAelBfwIIQYMBKUF/AshBgwBpQX8DiEGDA4lFfwBIRYMCyUV/AQhFgwIJRX8ByEWDAUlFfwKIRYMAiUV/A0hFgwPJQX8AKEGDAwlBfwDoQYMCSUF/AahBgwGJQX8CaEGDAMlBfwMoQYMACUF/A+hBgwNxRX8AqEWDArFFfwFoRYMB8UV/AihFgwExRX8C6EWDAHFFfwOoRYMDsUF+gOSDAgHmhvkAzQYABM0J9geaDAAPmgvoCzQoBBswC9QWaGwIMyI/6As0QAQZkRn2B5okAA3KivkCzRYAB2VBfoDkjwIA8qC/QzBFgQAbUFwABBpoa9QUgCDDQxKgvAAkBBpoO9QWgRoCBJkJ9AWgiwEBToL4AtBBgwOSoL4DaCDBgWtQXwC0RYMCEqC+AuhBgwFSoLwAdCDBgEtQXgG4EGDA+6gugXgQYMDLqC6AhCDBgTNQXQAMRYMBoqC+AhiPAgHFQXwB6IcCAEVBfAPoiwEBjUV8ABiDAQKNQXwCGIcCA4agvAIMRYMBA1BdAYxBgwBDUF0AjEWBAb9QXQOMRYEA/1BeAURBgQA/UF4CxEGCgoagvACMiwECDUF8AxkWAgfpRXwBGR4CBelBfAKZAgAFdqC8AEyHAQJ2oLwDTIcDArVFfACZFgIFboL4ATI0AA9qoL4AmQICBf6G+AJoGAQb+h/oCaDIEGPg/1BdAUyLAgBDUF0CTI8AA9QUgAwKM5o76ApAFAUazRn0ByIUAo/mivgBkRIDRTFFfAPIiwGiOqC8A2RFgNDvUF4A5IMBoXqgvADNBgNGMUF8A5oMAo7mgvgDMCgFGs0B9AZgbAgzrR30BmCECDCtHfQGYJwIMa0Z9AZgtAgyrRX0BmDMCDOtEfQGYOQIMK0R9AZg/AgxrQ30BWAQCDKtCfQFYCgIM60F9AVgQAgwrQX0BWBYCDGtAfQFYHAIMi0d9AVgiAgzLRn0BWCgCDAtGfQFYLgIMS0V9AVg0AgyLRH0BWDoCDMtDfQFYAQIMC0N9AVgHAgxLQn0BWA0CDItBfQFYEwIMy0B9AVgZAgwLQH0BWB8CDHNHfQFYJQIMs0Z9AVgrAgzzRX0BWDECDDNFfQFYNwIMc0R9AVg9AgyzQ30BNAc2KpVK7jnA2pSXlx88ePBA1N8XzxxPTUvLyc13cLD3aeEdGhrWs/9tI2+/o3fv3nVtS33RHMTGxu6J3Hv46InLly/n5edVlJe3aOHTpm3bXj26jR09cvjw4c7OznLPESZHgGFMCQkJq955Y1/k38PbK0cGFXRvrQr2Fh5OQqkSOaUiOU+cuGYbmeadkO/wyMy5T81/wcPDQ2tz6gsrVlpa+sVXX3+1Zp2Ni7dTUDfX1h1dWvjbu3jYKBTVFWXlhdklWamVmZcKUs6PGH7b6/99qUuXLnJPGSZEgGEceXl5ry6af/LArsVD8id2Udnb6lo5v0ysPeG0/ozrsy+8+uQz/7G1tRXUF1ZNpVJ9s279suUrvDrd1qr3nfYuHrpWVipz409kH982sE/3zz9Z5efn12TzRFMiwDCC6Oj9T82c9vzAvNl9qxQN7mZRuViyz/18eccff9158+ZN6gtrlZOTM/mBBzPLHYJGPmrv7N7wDbNio7OPbVn75eo777zTdNODXAgwGuun77/9ZPkLm6bmt29hyOZ/XlIs3OMz59nFgYGB1BfWJykpacyd47373efbeagBm1cU5SbuWLV4/hPzn33a6HODvAgwGmXjj99/uWLBHw8XeDoZPsiZDDF5o8fbq76eNm0a9YU1SU9Pv23kGP/Rcz3bdjZ4kJqqioSt7y2cN4MGWxkCDMPFxBx+9tHxe2fmezX6hM1jaWLurqDoY7Genp7GmBogv7Kyst79B3kMfNC7XfdGDlVTWX5p07L1n31wxx13GGVuMAcEGAYqLi4e0qfT75MzwloaZ8ANJx0iK8f89FuEcYYD5Dbr8Xkns2z8+08wymjlhTmJvy8/czzG19fXKANCdtyIAwZa+t+Fc3vkNqS+xRUNGnBW38qCxJjIyD2NnBhgDo4ePbrv0DH/fuONNaCTp69vv4nzn3/RWANCduwBwxAZGRl33db91FN5tnW8hPv9nPjplDieLjKLRY1SeDmL8JbiiUFiZn+h4zTpy9li5t9hMacvm2jaQJMZPGyU6DrRIzC0ISsXpl+Ki/hKCNG6+4h2QyfVuZ5KdfHHV/bu/D0sLMxY84SM2AOGIT77aOWCgUV11VcI8ds5se2CcHMUY0LFfd1EsLc4mibmbBZzf9U1bHhL0dYxZ//+/UafMNCUzp49e73gZgPrq6yuurD906KMhKKMhIqiHF2r2tj49pu4/N33jTNLyI0AQ29KpXLrb79M61GtY52FI0Tm6yJusdg1V2ydKc68IP5+QjjaifXHxOEUXYPP7pH3/TefGHfCQBP76pv1nl1GNXDlxH82lmantwwf0JCVW4b13xO5t6KiYe/rwLwRYOjt3LlzXfyUrg661unXRrT69/0G7ggTE7sKIcSRVF0b3h4qDh44wDsjplBdXb1y5cpHHnnk/vvvX7JkSVZWltwzslp//b3bN6x/Q9Ysvp6ccmhL8JD7vNp0asj6NrZ2Xm27xMTENG6CMAsEGHo7GL1/RGCBARs62gkhhO5rluwUoqOvTUJCgkFTgy7V1dVZWVkTJkyYNWtWXFzcyJEja2pq5J6UFcrOzlbZOto61H9pvEpZc2Hrx07uLTqMerjh49u3Dt8b9Y/h84PZsJN7ArA8F88cmdJK1/HnWzqTIbZfEB5OYnx9t5fv2rIiLi4uNLRB75+h4ZycnD788EPpv0ePHu3m5paamhoSEiLvrKxPXFycq1/bhqyZFL25KDOx74w3G1JrNVe/4FNnow2dHcwIAYberqWnBvVt0Jp/XBQ7L4rKGpGcJw4kiY6+4tvpws+tnq3auhTv3/+Pj49P46eKWyovL4+IiGjTpk1aWlpmZqbc07E2UVFRKqf67ydTmp2eHP1rQK/RPh376DW+s2fLq8euGjo7mBECDL2VlJS4OTZozZNXxZoj//ffTnZiQhfRsQFVdXNQ3chIT0tLM3yKqNubb76ZkJDg4OCwcOFC6msKV69eFbb17NGqlMrYLatsHZzCxs3Rd3xbB+eS4mJDZwczQoChN3t7+6qGvXX40iixYJgorRTx2eKrGPHhfrHlvDj6H9FS505wlVIoHHSe4oVGeP3111Uq1fHjxz/44IP33nuPIw1GZ2dnp1KW6V4n5dCWwmvx3ae86OCq971XlTXV9vb2hs4OZoQAQ2/eLVrk3RTB3vWv6WwvnO2Ft7MI8hSjOgoHO/HjSfFulPhQ5735cssdBo4YMm7cOGNNGLXdeeedu3btcnV15Xk2OqVSGX3lDx0rlOVfT/znZ9/Qfv49RhowflVZkXcLgz56DGaGAENvoZ17xF+L7B2o94YP9xY/nqznMiQhREKR+8yePVvwJ8bYcnNznZycXF1dhRCxsbGpqan9+/fneTa6Xr16VRet1bFCSVaasqoyPzU26p3p6oU11ZVCiPTjf2ac2dsipGfPaa/UtfnN3Izu4dwJyxoQYOit94DbDn259oGeRfpuWF4thBDK+i7xPXlVrOrRw6CpQZfTp08/8MADoaGhSqUyPj7+zTff7Natm9yTskJhYWFFN3SdweDg4uHToZfWwrL8GzfzMh1cvVx9A118AnRsXnY9cdgDw4wwUciNAENvw4cPf2uRrreglCphI4TWB/uqVGLjaSGE6Beka/BrhcLFw8fDw6Px84SWMWPGpKamXrlyxdbWtkOHDu7u7vVvA/3Z29u3b9+uJDvNreWtL0bybNOp72PLtRYmR2+Oj/y+VZch4XfN1T1+adq5229faoyZQmYEGHrz8fHxC2x/PjO3u/+tV7hWKEZ/JR4fKPoEijZeoqpGXMkWXxwW+xKEu6N4friuwTeec5j68GxTTBtCCHd39759G3YNGRrh8ZmPfPhzpFvLh4w+cnlhtpujTXBwsNFHRtMjwDDEvAWvfPLx7LUTC2/5VTuFSM0XL9f6YN9QX/H9gyKk7rNuq2rEt2fdor4hwLBsD0yd+trS5f6DJ9vaN+yKvQbLPvXn8888ZdwxIRc+jhCGUCqV/bt32Dghpa7PAy6pEP8kinOZ4nqxqFGKAA8xMFiM6iB0fICSEOLLow6JrWd+8OnXppgz0JRee33pthPpgYPvb+D6pdnpJVmpLj4B7q3rvDdZeVFOypYVCZdiuQzJOhBgGCgqat+KBVN2z8i3qfvzffWSUSTGfO93+PRlLy8v44wIyKesrKxz995t713s7N3KOCOqVAnb3v9gyXOTJtX9gcGwKHwYAww0atTosEET3jvoYpTRyqvF1E1eH335LfWFdXB2dt6w9qvkiI+VNXrfOP2WMo5sGdQthPpaEwIMw61avSYis8Pm8409k0ClEnO3e0yZs3jcnXcZZWKAORg1cuSTsx5O2vlJ4w805l455ph3ecNa3p2xKhyCRqPk5+ffOWrgM91SZ/SuNGyEsioxe5tny173ffrVt0adGmAWnlu46I/9J0LuWaCwM/CN26xz+25e3HMgKtLPz8+4c4O82ANGo3h7e++JPrExo8/zf7lX6H+kLb1AjNrgPfTBJdQX1urjD99//IG7L218/Wae3h99oVLWpO37tkXhxRNHDlFf68MeMIxAqVS+t2LpxvWfLx+VP76zqiGnZZVVic+POn173uvTr38cffvtpp8jIKf90dEz58xz6TCgdb8Jdo7ODdkkL/F0xoGfHp0+ZcVbyxQKdpasEAGG0SQlJb3x8oJLZ2Jm9iya3LWqdR33WTqXKTZdcN0S5zT9kTkvvvK6dGtiwOqVl5e//+Gqr9as8+zQz6vTUPfWIdq3ixNCCFFZWphz+UjhxX+6hnf46L13OnXq1PRTRdMgwDCy9PT0H79du3PrLyWFuZ38bII9KrydqqtqRH6lU3yeXXxWTXh4+JRH5t4/eaqbm85PJQSsUVlZ2datW9d///OFCxdcfQOcvP1V9i42tvaqytLqktzS7Ksers6TJk6YM+uxkJA6LwiGdSDAMJWbN29euXIlNTW1uLjYzs7O09MzNDS0Xbt2dnbcfw0QNTU1qamp8fHxhYWF5eXlHh4ebdu2DQsL44Vp80GAAQCQAW/sAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgAwIMAIAMCDAAADIgwAAAyIAAAwAgg/8HfXKXBbB93rEAAAAASUVORK5CYII="
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fixed_positions = Dict(\n",
     "    1 => (-1.0, 1.0),\n",
@@ -459,10 +549,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "cover-application",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "selected_vertices (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "cover_edges = [(1, 2), (1, 3), (2, 3), (3, 4)]\n",
     "cover_penalty = 2\n",
@@ -479,10 +580,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "cover-model",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$ 2 cover\\_x_{1}\\times cover\\_x_{2} + 2 cover\\_x_{1}\\times cover\\_x_{3} + 2 cover\\_x_{2}\\times cover\\_x_{3} + 2 cover\\_x_{3}\\times cover\\_x_{4} - 3 cover\\_x_{1} - 3 cover\\_x_{2} - 5 cover\\_x_{3} - cover\\_x_{4} + 8 $"
+      ],
+      "text/plain": [
+       "2 cover_x[1]*cover_x[2] + 2 cover_x[1]*cover_x[3] + 2 cover_x[2]*cover_x[3] + 2 cover_x[3]*cover_x[4] - 3 cover_x[1] - 3 cover_x[2] - 5 cover_x[3] - cover_x[4] + 8"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "cover_model = Model()\n",
     "@variable(cover_model, cover_x[1:4], Bin)\n",
@@ -495,10 +610,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "cover-check",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x=[1, 0, 1, 0]: selected=[1, 3], uncovered=Tuple{Int64, Int64}[], raw energy=2\n",
+      "x=[0, 1, 1, 0]: selected=[2, 3], uncovered=Tuple{Int64, Int64}[], raw energy=2\n"
+     ]
+    }
+   ],
    "source": [
     "cover_states = assert_all_states_match(\n",
     "    cover_model,\n",
@@ -546,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "exercise-partition",
    "metadata": {},
    "outputs": [],
@@ -558,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "solution-partition",
    "metadata": {
     "tags": [
@@ -566,7 +690,15 @@
      "solution"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best imbalance: 1; labeled optima: [[1, 1, 1, 0], [0, 0, 0, 1]]\n"
+     ]
+    }
+   ],
    "source": [
     "# SOLUTION (hidden in workshop version):\n",
     "practice_partition_weights = [1, 2, 3, 7]\n",
@@ -581,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "exercise-maxcut",
    "metadata": {},
    "outputs": [],
@@ -592,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "solution-maxcut",
    "metadata": {
     "tags": [
@@ -600,7 +732,15 @@
      "solution"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best cut weight: 9; labeled optima: [[1, 0, 1, 0], [0, 1, 0, 1]]\n"
+     ]
+    }
+   ],
    "source": [
     "# SOLUTION (hidden in workshop version):\n",
     "practice_weighted_edges = [weighted_edges; (1, 4, 2)]\n",
@@ -613,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "exercise-cover",
    "metadata": {},
    "outputs": [],
@@ -624,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "solution-cover",
    "metadata": {
     "tags": [
@@ -632,7 +772,15 @@
      "solution"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "With P=1, infeasible best-energy states include [[0, 0, 1, 0]]\n"
+     ]
+    }
+   ],
    "source": [
     "# SOLUTION (hidden in workshop version):\n",
     "weak_cover_penalty = 1\n",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ notebook_links = [
     "notebooks_jl/5-Benchmarking.ipynb",
     "notebooks_py/5-Benchmarking_python.ipynb",
     "notebooks_py/6-QCi_python.ipynb",
+    "notebooks_jl/7-CanonicalProblems.ipynb",
 ]
 files_with_repository_links = [
     "README.md",

--- a/tests/test_canonical_problems_notebook.py
+++ b/tests/test_canonical_problems_notebook.py
@@ -20,6 +20,21 @@ def notebook_source() -> str:
     )
 
 
+def notebook_cell(data: dict, cell_id: str) -> dict:
+    matches = [cell for cell in data["cells"] if cell.get("id") == cell_id]
+    if len(matches) != 1:
+        raise AssertionError(f"Expected one cell with id {cell_id!r}, found {len(matches)}")
+    return matches[0]
+
+
+def cell_output_text(cell: dict) -> str:
+    output_parts = []
+    for output in cell.get("outputs", []):
+        value = output.get("text", output.get("data", {}).get("text/plain", ""))
+        output_parts.append("".join(value) if isinstance(value, list) else value)
+    return "\n".join(output_parts)
+
+
 def binary_states(size: int) -> list[tuple[int, ...]]:
     return list(itertools.product((0, 1), repeat=size))
 
@@ -92,13 +107,57 @@ class CanonicalProblemsNotebookSourceTests(unittest.TestCase):
             with self.subTest(out_of_scope_name=out_of_scope_name):
                 assert_source_excludes(self, source, out_of_scope_name)
 
-    def test_notebook_keeps_outputs_uncommitted(self) -> None:
+    def test_notebook_commits_reproducible_teaching_outputs(self) -> None:
         data = notebook()
         code_cells = [cell for cell in data["cells"] if cell["cell_type"] == "code"]
+        populated_cells = [cell for cell in code_cells if cell.get("outputs", [])]
 
         self.assertTrue(code_cells)
-        self.assertTrue(all(cell.get("outputs", []) == [] for cell in code_cells))
-        self.assertTrue(all(cell.get("execution_count") is None for cell in code_cells))
+        self.assertEqual(
+            list(range(1, len(code_cells) + 1)),
+            [cell.get("execution_count") for cell in code_cells],
+        )
+        self.assertGreaterEqual(len(populated_cells), 10)
+        self.assertEqual([], notebook_cell(data, "bootstrap").get("outputs", []))
+        self.assertEqual([], notebook_cell(data, "activate").get("outputs", []))
+
+        expected_output_markers = {
+            "partition-check": "imbalance=0, raw energy=0",
+            "maxcut-check": "cut weight=7, raw energy=-7",
+            "cover-check": "selected=[1, 3], uncovered=Tuple{Int64, Int64}[]",
+            "solution-partition": "Best imbalance: 1",
+            "solution-maxcut": "Best cut weight: 9",
+            "solution-cover": "infeasible best-energy states include [[0, 0, 1, 0]]",
+        }
+        for cell_id, marker in expected_output_markers.items():
+            with self.subTest(cell_id=cell_id):
+                self.assertTrue(
+                    marker in cell_output_text(notebook_cell(data, cell_id)),
+                    f"Missing output marker in {cell_id!r}: {marker!r}",
+                )
+
+        plot_outputs = notebook_cell(data, "maxcut-plot").get("outputs", [])
+        png_outputs = [
+            output.get("data", {}).get("image/png", "") for output in plot_outputs
+        ]
+        self.assertTrue(any(len(image) > 1_000 for image in png_outputs))
+        self.assertFalse(
+            any(
+                output.get("output_type") == "error"
+                for cell in code_cells
+                for output in cell.get("outputs", [])
+            )
+        )
+
+        serialized_outputs = json.dumps(
+            [cell.get("outputs", []) for cell in code_cells], ensure_ascii=False
+        )
+        for marker in ("/home/", "/Users/", "C:\\Users", "AppData", "Bearer "):
+            with self.subTest(forbidden_output_marker=marker):
+                self.assertFalse(
+                    marker in serialized_outputs,
+                    f"Forbidden marker in committed outputs: {marker!r}",
+                )
 
     def test_notebook_and_verifier_are_linked(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text()

--- a/tests/test_canonical_problems_notebook.py
+++ b/tests/test_canonical_problems_notebook.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import itertools
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "7-CanonicalProblems.ipynb"
+
+
+def notebook() -> dict:
+    return json.loads(NOTEBOOK_PATH.read_text())
+
+
+def notebook_source() -> str:
+    return "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook()["cells"]
+    )
+
+
+def binary_states(size: int) -> list[tuple[int, ...]]:
+    return list(itertools.product((0, 1), repeat=size))
+
+
+def assert_source_contains(
+    test_case: unittest.TestCase, source: str, marker: str
+) -> None:
+    test_case.assertTrue(marker in source, f"Missing notebook source marker: {marker!r}")
+
+
+def assert_source_excludes(
+    test_case: unittest.TestCase, source: str, marker: str
+) -> None:
+    test_case.assertFalse(marker in source, f"Forbidden notebook source marker: {marker!r}")
+
+
+class CanonicalProblemsNotebookSourceTests(unittest.TestCase):
+    def test_notebook_has_tutorial_structure_and_clean_room_references(self) -> None:
+        source = notebook_source()
+        required_sections = (
+            "## Setup",
+            "## Learning objectives",
+            "## Prerequisites",
+            "## Number partitioning",
+            "## Max-Cut",
+            "## Minimum vertex cover",
+            "## Practice checkpoints",
+            "## Summary",
+            "## References",
+        )
+
+        for section in required_sections:
+            with self.subTest(section=section):
+                assert_source_contains(self, source, section)
+
+        assert_source_contains(self, source, "https://doi.org/10.1287/educ.2025.0288")
+        assert_source_contains(
+            self,
+            source,
+            "https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers",
+        )
+        assert_source_contains(self, source.lower(), "original julia derivations")
+
+    def test_notebook_uses_public_deterministic_credential_free_path(self) -> None:
+        source = notebook_source()
+
+        required_markers = (
+            "QUBO.ExactSampler.Optimizer",
+            "evaluate_jump_objective",
+            "assert_all_states_match",
+            "exact_sampler_optima!",
+            "fixed_positions",
+            "partition_weights = [1, 3, 4, 8]",
+            "(3, 4, 3),",
+            "cover_edges = [(1, 2), (1, 3), (2, 3), (3, 4)]",
+            "@assert partition_best_energy == 0",
+            "@assert maxcut_best_energy == -7",
+            "@assert cover_best_energy == 2",
+            "@assert length(partition_optima) == 2",
+            "@assert length(maxcut_optima) == 4",
+            "@assert length(cover_optima) == 2",
+        )
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                assert_source_contains(self, source, marker)
+
+        assert_source_excludes(self, source, "unsafe_backend")
+
+        for out_of_scope_name in ("Qiskit", "OpenQAOA", "D-Wave", "token", "API key"):
+            with self.subTest(out_of_scope_name=out_of_scope_name):
+                assert_source_excludes(self, source, out_of_scope_name)
+
+    def test_notebook_keeps_outputs_uncommitted(self) -> None:
+        data = notebook()
+        code_cells = [cell for cell in data["cells"] if cell["cell_type"] == "code"]
+
+        self.assertTrue(code_cells)
+        self.assertTrue(all(cell.get("outputs", []) == [] for cell in code_cells))
+        self.assertTrue(all(cell.get("execution_count") is None for cell in code_cells))
+
+    def test_notebook_and_verifier_are_linked(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text()
+        makefile = (REPO_ROOT / "Makefile").read_text()
+
+        self.assertIn("notebooks_jl/7-CanonicalProblems.ipynb", readme)
+        self.assertIn("make verify-canonical-problems-julia", readme)
+        self.assertIn("verify-canonical-problems-julia:", makefile)
+        self.assertIn(
+            'NOTEBOOKS="$(CANONICAL_PROBLEMS_JULIA_NOTEBOOK)"', makefile
+        )
+
+
+class CanonicalProblemsMathematicalInvariantTests(unittest.TestCase):
+    def test_number_partitioning_expansion_and_decoded_optima(self) -> None:
+        weights = (1, 3, 4, 8)
+        total = sum(weights)
+
+        def imbalance(bits: tuple[int, ...]) -> int:
+            return sum(weight * (1 - 2 * bit) for weight, bit in zip(weights, bits))
+
+        def expanded_energy(bits: tuple[int, ...]) -> int:
+            constant = total**2
+            linear = sum(
+                (4 * weight**2 - 4 * total * weight) * bit
+                for weight, bit in zip(weights, bits)
+            )
+            quadratic = sum(
+                8 * weights[i] * weights[j] * bits[i] * bits[j]
+                for i in range(len(weights))
+                for j in range(i + 1, len(weights))
+            )
+            return constant + linear + quadratic
+
+        states = binary_states(len(weights))
+        self.assertTrue(
+            all(expanded_energy(bits) == imbalance(bits) ** 2 for bits in states)
+        )
+        optimum = min(expanded_energy(bits) for bits in states)
+        optima = {bits for bits in states if expanded_energy(bits) == optimum}
+
+        self.assertEqual(0, optimum)
+        self.assertEqual({(0, 0, 0, 1), (1, 1, 1, 0)}, optima)
+
+    def test_max_cut_minimization_sign_and_decoded_optima(self) -> None:
+        weighted_edges = (
+            (1, 2, 2),
+            (1, 3, 1),
+            (2, 3, 2),
+            (2, 4, 1),
+            (3, 4, 3),
+        )
+
+        def cut_weight(bits: tuple[int, ...]) -> int:
+            return sum(
+                weight if bits[i - 1] != bits[j - 1] else 0
+                for i, j, weight in weighted_edges
+            )
+
+        def qubo_energy(bits: tuple[int, ...]) -> int:
+            return -sum(
+                weight
+                * (
+                    bits[i - 1]
+                    + bits[j - 1]
+                    - 2 * bits[i - 1] * bits[j - 1]
+                )
+                for i, j, weight in weighted_edges
+            )
+
+        states = binary_states(4)
+        self.assertTrue(all(qubo_energy(bits) == -cut_weight(bits) for bits in states))
+        optimum = min(qubo_energy(bits) for bits in states)
+        optima = {bits for bits in states if qubo_energy(bits) == optimum}
+
+        self.assertEqual(-7, optimum)
+        self.assertEqual(
+            {
+                (1, 0, 1, 0),
+                (0, 1, 1, 0),
+                (1, 0, 0, 1),
+                (0, 1, 0, 1),
+            },
+            optima,
+        )
+
+    def test_vertex_cover_penalty_expansion_and_decoded_optima(self) -> None:
+        edges = ((1, 2), (1, 3), (2, 3), (3, 4))
+        penalty = 2
+        degrees = [sum(vertex in edge for edge in edges) for vertex in range(1, 5)]
+
+        def uncovered_edges(bits: tuple[int, ...]) -> int:
+            return sum(bits[i - 1] == 0 and bits[j - 1] == 0 for i, j in edges)
+
+        def application_energy(bits: tuple[int, ...]) -> int:
+            return sum(bits) + penalty * uncovered_edges(bits)
+
+        def expanded_energy(bits: tuple[int, ...]) -> int:
+            constant = penalty * len(edges)
+            linear = sum(
+                (1 - penalty * degrees[i]) * bits[i] for i in range(len(bits))
+            )
+            quadratic = penalty * sum(
+                bits[i - 1] * bits[j - 1] for i, j in edges
+            )
+            return constant + linear + quadratic
+
+        states = binary_states(4)
+        self.assertTrue(
+            all(expanded_energy(bits) == application_energy(bits) for bits in states)
+        )
+        optimum = min(expanded_energy(bits) for bits in states)
+        optima = {bits for bits in states if expanded_energy(bits) == optimum}
+
+        self.assertEqual(2, optimum)
+        self.assertEqual({(1, 0, 1, 0), (0, 1, 1, 0)}, optima)
+        self.assertTrue(all(uncovered_edges(bits) == 0 for bits in optima))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -26,6 +26,9 @@ BENCHMARKING_JULIA_NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "5-Benchmarking.
 BENCHMARKING_PYTHON_NOTEBOOK_PATH = (
     REPO_ROOT / "notebooks_py" / "5-Benchmarking_python.ipynb"
 )
+CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH = (
+    REPO_ROOT / "notebooks_jl" / "7-CanonicalProblems.ipynb"
+)
 BENCHMARKING_RESULTS_ARCHIVES = (
     REPO_ROOT / "notebooks_py" / "results.zip",
     REPO_ROOT / "notebooks_jl" / "results.zip",
@@ -36,6 +39,7 @@ JULIA_COLAB_NOTEBOOK_PATHS = (
     REPO_ROOT / "notebooks_jl" / "3-GAMA.ipynb",
     REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb",
     REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb",
+    CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH,
 )
 BOOTSTRAP_PATH = REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
 NOTEBOOK_DIRS = (


### PR DESCRIPTION
## Summary

- add an original Julia tutorial notebook deriving number partitioning, weighted Max-Cut, and minimum vertex cover QUBOs
- exhaustively compare application-level scores with the full JuMP objectives for every binary state, including constants and minimization direction
- compare optimum energies and complete degeneracy with `QUBO.ExactSampler.Optimizer`, decode solutions, and use a fixed-layout Max-Cut visualization
- commit freshly executed solution summaries, expanded objectives, and the deterministic Max-Cut PNG
- add a targeted fresh-kernel verifier target, README navigation, notebook inventories, and independent source/mathematical invariant tests

## Validation

- `make verify-canonical-problems-julia`
- `.venv/bin/python -m unittest discover -s tests` (109 tests)
- `make test-julia`
- `make test`
- `make check-notebook-output-hygiene`
- `UV_CACHE_DIR=.uv-cache uv lock --check`
- `git diff --check`

The targeted verifier restarted a Julia kernel and executed all cells successfully. The executed copy confirmed two perfect labeled partitions, four labeled maximum cuts of weight 7, and two feasible minimum covers of size 2. A mutation changing the committed partition instance caused the source guard to fail, and the pre-output notebook failed the new committed-output regression, confirming both guards are non-vacuous.

## Notebook execution and dependencies

The committed outputs were generated by the targeted verifier in a fresh Julia 1.10 kernel. Environment-specific setup logs and transient execution timing metadata were removed; the plot keeps the deterministic PNG while dropping the SVG variant whose internal clip identifiers vary between Julia processes. A third fresh execution, passed through the same sanitization, was byte-identical to the committed notebook. No new dependency was needed; `notebooks_jl/Project.toml` and `notebooks_jl/Manifest.toml` are unchanged.

## Branch Hygiene

- base branch: `main`
- source branch point: `51edc460f213131faa5b1694a719e684b50cb2fd`
- stacked status: not stacked; no prerequisite PR
- open PR overlap: #89 changes only `pyproject.toml` and `uv.lock`, so there is no file or hunk overlap

## Coordination

This PR completes the canonical-modeling notebook tracked by #92. It advances roadmap #90 without closing it; #93-#97 remain independent follow-up work.

Closes #92
