### PR TITLE
Add corrected Julia order-partitioning case study

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-canonical-problems-julia
+.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-canonical-problems-julia verify-order-partitioning-julia
 
 PYTHON ?= python3
 UV ?= uv
@@ -15,6 +15,7 @@ PORTABLE_PYTHON_NOTEBOOKS ?= $(QUBO_PYTHON_NOTEBOOK) $(GAMA_PYTHON_NOTEBOOK)
 DWAVE_PYTHON_NOTEBOOK ?= notebooks_py/4-DWAVE_python.ipynb
 BENCHMARKING_PYTHON_NOTEBOOK ?= notebooks_py/5-Benchmarking_python.ipynb
 CANONICAL_PROBLEMS_JULIA_NOTEBOOK ?= notebooks_jl/7-CanonicalProblems.ipynb
+ORDER_PARTITIONING_JULIA_NOTEBOOK ?= notebooks_jl/8-OrderPartitioning.ipynb
 NOTEBOOKS ?= $(PORTABLE_PYTHON_NOTEBOOKS)
 NOTEBOOK_FILES ?= notebooks_jl/*.ipynb notebooks_py/*.ipynb
 
@@ -70,3 +71,6 @@ verify-benchmarking-python:
 
 verify-canonical-problems-julia:
 	$(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(CANONICAL_PROBLEMS_JULIA_NOTEBOOK)"
+
+verify-order-partitioning-julia:
+	$(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(ORDER_PARTITIONING_JULIA_NOTEBOOK)"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ long benchmark runs.
 | Benchmarking | [notebooks_jl/5-Benchmarking.ipynb](notebooks_jl/5-Benchmarking.ipynb) | [notebooks_py/5-Benchmarking_python.ipynb](notebooks_py/5-Benchmarking_python.ipynb) | Julia notebook includes native Colab setup through the shared notebook project; benchmark runs are long-running and generate artifacts. |
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
 | Canonical QUBO starter problems | [notebooks_jl/7-CanonicalProblems.ipynb](notebooks_jl/7-CanonicalProblems.ipynb) | Not available | Credential-free Julia notebook covered by `make verify-canonical-problems-julia`; exhaustive checks validate number partitioning, Max-Cut, and minimum vertex cover. |
+| Order partitioning for A/B testing | [notebooks_jl/8-OrderPartitioning.ipynb](notebooks_jl/8-OrderPartitioning.ipynb) | Not available | Credential-free Julia notebook covered by `make verify-order-partitioning-julia`; all 64 assignments validate the grouped value/risk objective and decoded balances. |
 
 ## Local verification
 
@@ -64,6 +65,7 @@ make test-julia
 make verify-qubo-python
 make verify-gama-python
 make verify-canonical-problems-julia
+make verify-order-partitioning-julia
 ```
 
 The generic verifier can execute selected notebooks by overriding `NOTEBOOKS`

--- a/notebooks_jl/8-OrderPartitioning.ipynb
+++ b/notebooks_jl/8-OrderPartitioning.ipynb
@@ -1,0 +1,928 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "<a name=\"top\" id=\"top\"></a>\n",
+    "\n",
+    "<div align=\"center\">\n",
+    "  <h1>Order Partitioning for A/B Testing</h1>\n",
+    "  <p>An original Julia case study with a corrected grouped-risk objective and exact checks.</p>\n",
+    "  <a href=\"https://colab.research.google.com/github/JuliaQUBO/QUBONotebooks/blob/main/notebooks_jl/8-OrderPartitioning.ipynb\" target=\"_parent\">\n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "  </a>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "### Local installation\n",
+    "\n",
+    "From the repository root, instantiate the shared Julia environment before opening this notebook:\n",
+    "\n",
+    "    julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
+    "\n",
+    "Run this notebook from a clean kernel with:\n",
+    "\n",
+    "    make verify-order-partitioning-julia\n",
+    "\n",
+    "The default workflow is credential-free, uses no external data, and solves the six-order instance locally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "colab",
+   "metadata": {},
+   "source": [
+    "### Google Colab\n",
+    "\n",
+    "Open the badge above, select a Julia runtime, and run the setup cells. The bootstrap clones this repository only when Colab does not already have it, then activates the same checked-in notebook project used locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bootstrap",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function load_qubonotebooks_bootstrap()\n",
+    "    candidates = (\n",
+    "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+    "    )\n",
+    "\n",
+    "    for candidate in candidates\n",
+    "        if isfile(candidate)\n",
+    "            include(candidate)\n",
+    "            return nothing\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+    "    if in_colab\n",
+    "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+    "        if !isdir(repo_dir)\n",
+    "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+    "            run(Cmd([\"git\", \"clone\", \"--depth\", \"1\", \"https://github.com/JuliaQUBO/QUBONotebooks.git\", repo_dir]))\n",
+    "        end\n",
+    "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+    "        return nothing\n",
+    "    end\n",
+    "\n",
+    "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+    "end\n",
+    "\n",
+    "load_qubonotebooks_bootstrap()\n",
+    "\n",
+    "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"8-OrderPartitioning\")\n",
+    "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+    "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+    "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+    "IN_COLAB = BOOTSTRAP.in_colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "activate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import Pkg\n",
+    "\n",
+    "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
+    "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
+    "if python_warning_filter ∉ python_warning_filters\n",
+    "    push!(python_warning_filters, python_warning_filter)\n",
+    "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+    "end\n",
+    "\n",
+    "if @isdefined(JULIA_PROJECT_DIR)\n",
+    "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+    "else\n",
+    "    Pkg.activate(@__DIR__)\n",
+    "end\n",
+    "Pkg.instantiate(; io = devnull)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "objectives",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this notebook you will be able to:\n",
+    "\n",
+    "1. formulate value and factor-risk balance as a QUBO with explicit weights;\n",
+    "2. explain why each risk-factor square must enclose the sum over orders;\n",
+    "3. verify all 64 assignments independently of the optimizer;\n",
+    "4. decode group values and risk exposures from an exact optimum; and\n",
+    "5. explain complement symmetry and the trade-off induced by the two weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prerequisites",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "**Prior notebooks:** Notebook 2 introduces JuMP and QUBO models; Notebook 7 develops exhaustive checking helpers. This notebook restates the helpers it needs so it remains useful on its own.\n",
+    "\n",
+    "**Mathematical background:** Binary variables, finite sums, squared deviations, and basic A/B testing terminology.\n",
+    "\n",
+    "**Software:** Julia 1.10+ with the shared notebook project instantiated.\n",
+    "\n",
+    "**Accounts required:** None."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using JuMP\n",
+    "using QUBO\n",
+    "using Printf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-context",
+   "metadata": {},
+   "source": [
+    "## Order-partitioning model\n",
+    "\n",
+    "Suppose a desk wants to assign indivisible orders to two labeled groups for an educational A/B comparison. Bit $x_j=0$ places order $j$ in group A and $x_j=1$ places it in group B. The value term minimizes the signed group-value difference, while each row of $p$ represents one factor exposure to balance.\n",
+    "\n",
+    "The fixture below is independently constructed for this notebook. Order values are in units of USD 100,000; the two risk rows are dimensionless synthetic factor-exposure scores. They are not observed trades, an empirical trading result, or investment advice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fixture",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Synthetic fixture: 6 orders, total value = $2.8M, risk factors = [\"market beta proxy\", \"liquidity proxy\"]\n"
+     ]
+    }
+   ],
+   "source": [
+    "order_names = [\"ORD-1\", \"ORD-2\", \"ORD-3\", \"ORD-4\", \"ORD-5\", \"ORD-6\"]\n",
+    "order_values = [2, 3, 4, 5, 6, 8]  # units of USD 100,000\n",
+    "risk_factor_names = [\"market beta proxy\", \"liquidity proxy\"]\n",
+    "risk_exposures = [\n",
+    "    1   1  2  5   4  5\n",
+    "    4  -2  3  6  -3  0\n",
+    "]\n",
+    "value_weight = 2\n",
+    "risk_weight = 1\n",
+    "\n",
+    "n_orders = length(order_values)\n",
+    "n_risk_factors = size(risk_exposures, 1)\n",
+    "total_value = sum(order_values)\n",
+    "\n",
+    "@assert size(risk_exposures, 2) == n_orders\n",
+    "@assert length(risk_factor_names) == n_risk_factors\n",
+    "println(\"Synthetic fixture: $n_orders orders, total value = \\$$(total_value / 10)M, risk factors = $risk_factor_names\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "formula",
+   "metadata": {},
+   "source": [
+    "For explicit positive weights $a$ and $b$, we minimize\n",
+    "\n",
+    "$$\n",
+    "Q(x)=a\\left(T-2\\sum_j q_jx_j\\right)^2\n",
+    "+b\\sum_i\\left(\\sum_j p_{ij}(2x_j-1)\\right)^2.\n",
+    "$$\n",
+    "\n",
+    "The parentheses are essential. For factor $i$, the inner sum is group B exposure minus group A exposure, so its square penalizes imbalance. Moving the square onto each $(2x_j-1)$ makes that term constant because $(2x_j-1)^2=1$ for binary $x_j$. The direct functions below are separate from the JuMP expression and serve as the independent reference calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "application-helpers",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "decoded_metrics (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function all_binary_states(n::Integer)\n",
+    "    states = Vector{Vector{Int}}()\n",
+    "    for state in Iterators.product(ntuple(_ -> (0, 1), n)...)\n",
+    "        push!(states, collect(state))\n",
+    "    end\n",
+    "    return states\n",
+    "end\n",
+    "\n",
+    "complement_bits(bits) = 1 .- bits\n",
+    "\n",
+    "signed_value_imbalance(values, bits) =\n",
+    "    sum(values[j] * (1 - 2 * bits[j]) for j in eachindex(values))\n",
+    "\n",
+    "function risk_imbalances(exposures, bits)\n",
+    "    return [\n",
+    "        sum(exposures[i, j] * (2 * bits[j] - 1) for j in axes(exposures, 2))\n",
+    "        for i in axes(exposures, 1)\n",
+    "    ]\n",
+    "end\n",
+    "\n",
+    "value_term(values, bits) = signed_value_imbalance(values, bits)^2\n",
+    "risk_term(exposures, bits) = sum(abs2, risk_imbalances(exposures, bits))\n",
+    "\n",
+    "function order_partitioning_energy(values, exposures, bits; a, b)\n",
+    "    return a * value_term(values, bits) + b * risk_term(exposures, bits)\n",
+    "end\n",
+    "\n",
+    "function incorrect_risk_term_square_inside(exposures, bits)\n",
+    "    return sum(\n",
+    "        exposures[i, j] * (2 * bits[j] - 1)^2\n",
+    "        for i in axes(exposures, 1), j in axes(exposures, 2)\n",
+    "    )\n",
+    "end\n",
+    "\n",
+    "function decoded_metrics(values, exposures, bits)\n",
+    "    group_a = findall(==(0), bits)\n",
+    "    group_b = findall(==(1), bits)\n",
+    "    group_a_value = sum(values[group_a])\n",
+    "    group_b_value = sum(values[group_b])\n",
+    "    group_a_risk = [sum(exposures[i, group_a]) for i in axes(exposures, 1)]\n",
+    "    group_b_risk = [sum(exposures[i, group_b]) for i in axes(exposures, 1)]\n",
+    "    signed_risk_imbalance = group_b_risk .- group_a_risk\n",
+    "\n",
+    "    return (\n",
+    "        group_a = group_a,\n",
+    "        group_b = group_b,\n",
+    "        group_a_value = group_a_value,\n",
+    "        group_b_value = group_b_value,\n",
+    "        signed_value_imbalance = group_a_value - group_b_value,\n",
+    "        absolute_value_imbalance = abs(group_a_value - group_b_value),\n",
+    "        group_a_risk = group_a_risk,\n",
+    "        group_b_risk = group_b_risk,\n",
+    "        signed_risk_imbalance = signed_risk_imbalance,\n",
+    "        absolute_risk_imbalance = abs.(signed_risk_imbalance),\n",
+    "        aggregate_risk_imbalance = sqrt(sum(abs2, signed_risk_imbalance)),\n",
+    "    )\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "verification-helpers",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "same_states (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function evaluate_jump_objective(model::Model, variables, bits)\n",
+    "    assignment = Dict(variables[i] => Float64(bits[i]) for i in eachindex(variables))\n",
+    "    return JuMP.value(variable -> assignment[variable], JuMP.objective_function(model))\n",
+    "end\n",
+    "\n",
+    "function exact_sampler_optima!(model::Model, variables; atol = 1e-9)\n",
+    "    set_optimizer(model, QUBO.ExactSampler.Optimizer)\n",
+    "    optimize!(model)\n",
+    "    @assert termination_status(model) in (JuMP.MOI.OPTIMAL, JuMP.MOI.LOCALLY_SOLVED)\n",
+    "\n",
+    "    energies = [objective_value(model; result = result) for result in 1:result_count(model)]\n",
+    "    best_energy = minimum(energies)\n",
+    "    optima = [\n",
+    "        round.(Int, value.(variables; result = result))\n",
+    "        for result in eachindex(energies)\n",
+    "        if isapprox(energies[result], best_energy; atol = atol, rtol = 0)\n",
+    "    ]\n",
+    "    return best_energy, optima\n",
+    "end\n",
+    "\n",
+    "same_states(left, right) = Set(Tuple.(left)) == Set(Tuple.(right))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "qubo-model",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$ 100 order\\_x_{1}^2 + 40 order\\_x_{2}\\times order\\_x_{1} + 240 order\\_x_{3}\\times order\\_x_{1} + 392 order\\_x_{4}\\times order\\_x_{1} + 128 order\\_x_{5}\\times order\\_x_{1} + 296 order\\_x_{6}\\times order\\_x_{1} + 92 order\\_x_{2}^2 + 160 order\\_x_{3}\\times order\\_x_{2} + 184 order\\_x_{4}\\times order\\_x_{2} + 368 order\\_x_{5}\\times order\\_x_{2} + 424 order\\_x_{6}\\times order\\_x_{2} + 180 order\\_x_{3}^2 + 544 order\\_x_{4}\\times order\\_x_{3} + 376 order\\_x_{5}\\times order\\_x_{3} + 592 order\\_x_{6}\\times order\\_x_{3} + 444 order\\_x_{4}^2 + 496 order\\_x_{5}\\times order\\_x_{4} + 840 order\\_x_{6}\\times order\\_x_{4} + 388 order\\_x_{5}^2 + 928 order\\_x_{6}\\times order\\_x_{5} + 612 order\\_x_{6}^2 - 648 order\\_x_{1} - 680 order\\_x_{2} - 1136 order\\_x_{3} - 1672 order\\_x_{4} - 1536 order\\_x_{5} - 2152 order\\_x_{6} + 1956 $"
+      ],
+      "text/plain": [
+       "100 order_x[1]² + 40 order_x[2]*order_x[1] + 240 order_x[3]*order_x[1] + 392 order_x[4]*order_x[1] + 128 order_x[5]*order_x[1] + 296 order_x[6]*order_x[1] + 92 order_x[2]² + 160 order_x[3]*order_x[2] + 184 order_x[4]*order_x[2] + 368 order_x[5]*order_x[2] + 424 order_x[6]*order_x[2] + 180 order_x[3]² + 544 order_x[4]*order_x[3] + 376 order_x[5]*order_x[3] + 592 order_x[6]*order_x[3] + 444 order_x[4]² + 496 order_x[5]*order_x[4] + 840 order_x[6]*order_x[4] + 388 order_x[5]² + 928 order_x[6]*order_x[5] + 612 order_x[6]² - 648 order_x[1] - 680 order_x[2] - 1136 order_x[3] - 1672 order_x[4] - 1536 order_x[5] - 2152 order_x[6] + 1956"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order_model = Model()\n",
+    "@variable(order_model, order_x[1:n_orders], Bin)\n",
+    "@objective(\n",
+    "    order_model,\n",
+    "    Min,\n",
+    "    value_weight * (total_value - 2 * sum(order_values[j] * order_x[j] for j in 1:n_orders))^2 +\n",
+    "    risk_weight * sum(\n",
+    "        (sum(risk_exposures[i, j] * (2 * order_x[j] - 1) for j in 1:n_orders))^2\n",
+    "        for i in 1:n_risk_factors\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exact-verification",
+   "metadata": {},
+   "source": [
+    "## Exact verification\n",
+    "\n",
+    "Six binary orders give only $2^6=64$ assignments. We compare the expanded JuMP objective with the direct displayed formula for every one, verify that the correct risk term is nonconstant, and check complement symmetry. The deliberately named incorrect helper exists only as a regression witness for the square-inside-the-sum defect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "all-state-check",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All 64 assignments match the direct grouped-square formula.\n",
+      "Correct risk term values: [4, 16, 20, 32, 36, 40, 80, 100, 104, 116, 128, 136, 160, 180, 196, 200, 212, 256, 296, 328, 388, 400]; square-inside regression witness: 26 for every assignment.\n"
+     ]
+    }
+   ],
+   "source": [
+    "states = all_binary_states(n_orders)\n",
+    "@assert length(states) == 64\n",
+    "\n",
+    "jump_energies = [evaluate_jump_objective(order_model, order_x, bits) for bits in states]\n",
+    "direct_energies = [\n",
+    "    order_partitioning_energy(\n",
+    "        order_values,\n",
+    "        risk_exposures,\n",
+    "        bits;\n",
+    "        a = value_weight,\n",
+    "        b = risk_weight,\n",
+    "    )\n",
+    "    for bits in states\n",
+    "]\n",
+    "@assert all(isapprox.(jump_energies, direct_energies; atol = 1e-9, rtol = 0))\n",
+    "\n",
+    "correct_risk_terms = [risk_term(risk_exposures, bits) for bits in states]\n",
+    "incorrect_risk_terms = [incorrect_risk_term_square_inside(risk_exposures, bits) for bits in states]\n",
+    "@assert length(unique(correct_risk_terms)) > 1\n",
+    "@assert length(unique(incorrect_risk_terms)) == 1\n",
+    "@assert all(\n",
+    "    direct_energies[index] == order_partitioning_energy(\n",
+    "        order_values,\n",
+    "        risk_exposures,\n",
+    "        complement_bits(bits);\n",
+    "        a = value_weight,\n",
+    "        b = risk_weight,\n",
+    "    )\n",
+    "    for (index, bits) in enumerate(states)\n",
+    ")\n",
+    "\n",
+    "println(\"All 64 assignments match the direct grouped-square formula.\")\n",
+    "println(\"Correct risk term values: $(sort(unique(correct_risk_terms))); square-inside regression witness: $(only(unique(incorrect_risk_terms))) for every assignment.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "exact-check",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enumerated optimum energy: 28\n",
+      "ExactSampler optimum energy: 28\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Global minima: [[1, 1, 1, 0, 1, 0], [0, 0, 0, 1, 0, 1]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "enumerated_best_energy = minimum(direct_energies)\n",
+    "enumerated_optima = states[findall(==(enumerated_best_energy), direct_energies)]\n",
+    "\n",
+    "exact_best_energy, exact_optima = exact_sampler_optima!(order_model, order_x)\n",
+    "@assert enumerated_best_energy == 28\n",
+    "@assert isapprox(exact_best_energy, enumerated_best_energy; atol = 1e-9, rtol = 0)\n",
+    "@assert same_states(exact_optima, enumerated_optima)\n",
+    "@assert length(enumerated_optima) == 2\n",
+    "@assert any(Tuple(bits) in Set(Tuple.(enumerated_optima)) for bits in exact_optima)\n",
+    "\n",
+    "println(\"Enumerated optimum energy: $(round(Int, enumerated_best_energy))\")\n",
+    "println(\"ExactSampler optimum energy: $(round(Int, exact_best_energy))\")\n",
+    "println(\"Global minima: $enumerated_optima\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decoded-heading",
+   "metadata": {},
+   "source": [
+    "## Decoded balances\n",
+    "\n",
+    "We select the optimum whose first order is in group A. Values are converted from the fixture's USD 100,000 units to millions of dollars. Risk exposure is reported factor by factor; the aggregate risk imbalance is the Euclidean norm of the signed factor differences. The raw QUBO energy remains the weighted sum of squared imbalances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "decoded-balance",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x = [0, 0, 0, 1, 0, 1]\n",
+      "Group A orders: ORD-1, ORD-2, ORD-3, ORD-5\n",
+      "Group B orders: ORD-4, ORD-6\n",
+      "Group A total: $1.5M\n",
+      "Group B total: $1.3M\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signed value imbalance (A-B): $+0.2M; absolute: $0.2M\n",
+      "market beta proxy: A=8, B=10, signed imbalance (B-A)=+2, absolute=2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "liquidity proxy: A=2, B=6, signed imbalance (B-A)=+4, absolute=4\n",
+      "Aggregate risk imbalance (L2): 4.472136\n",
+      "Raw QUBO energy: 28\n"
+     ]
+    }
+   ],
+   "source": [
+    "representative = first(filter(bits -> bits[1] == 0, enumerated_optima))\n",
+    "metrics = decoded_metrics(order_values, risk_exposures, representative)\n",
+    "\n",
+    "@assert metrics.group_a == [1, 2, 3, 5]\n",
+    "@assert metrics.group_b == [4, 6]\n",
+    "@assert metrics.group_a_value == sum(order_values[metrics.group_a]) == 15\n",
+    "@assert metrics.group_b_value == sum(order_values[metrics.group_b]) == 13\n",
+    "@assert metrics.signed_value_imbalance == 2\n",
+    "@assert metrics.absolute_value_imbalance == 2\n",
+    "@assert metrics.group_a_risk == [8, 2]\n",
+    "@assert metrics.group_b_risk == [10, 6]\n",
+    "@assert metrics.signed_risk_imbalance == [2, 4]\n",
+    "@assert metrics.absolute_risk_imbalance == [2, 4]\n",
+    "@assert isapprox(metrics.aggregate_risk_imbalance, sqrt(20); atol = 1e-12)\n",
+    "@assert risk_term(risk_exposures, representative) == sum(abs2, metrics.signed_risk_imbalance)\n",
+    "\n",
+    "println(\"x = $representative\")\n",
+    "println(\"Group A orders: $(join(order_names[metrics.group_a], \", \"))\")\n",
+    "println(\"Group B orders: $(join(order_names[metrics.group_b], \", \"))\")\n",
+    "@printf(\"Group A total: \\$%.1fM\\n\", metrics.group_a_value / 10)\n",
+    "@printf(\"Group B total: \\$%.1fM\\n\", metrics.group_b_value / 10)\n",
+    "@printf(\"Signed value imbalance (A-B): \\$%+.1fM; absolute: \\$%.1fM\\n\", metrics.signed_value_imbalance / 10, metrics.absolute_value_imbalance / 10)\n",
+    "for i in eachindex(risk_factor_names)\n",
+    "    @printf(\n",
+    "        \"%s: A=%d, B=%d, signed imbalance (B-A)=%+d, absolute=%d\\n\",\n",
+    "        risk_factor_names[i],\n",
+    "        metrics.group_a_risk[i],\n",
+    "        metrics.group_b_risk[i],\n",
+    "        metrics.signed_risk_imbalance[i],\n",
+    "        metrics.absolute_risk_imbalance[i],\n",
+    "    )\n",
+    "end\n",
+    "@printf(\"Aggregate risk imbalance (L2): %.6f\\n\", metrics.aggregate_risk_imbalance)\n",
+    "println(\"Raw QUBO energy: $(order_partitioning_energy(order_values, risk_exposures, representative; a = value_weight, b = risk_weight))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "complement-heading",
+   "metadata": {},
+   "source": [
+    "## Complement symmetry\n",
+    "\n",
+    "Replacing $x$ by $1-x$ swaps the two group labels. Every signed imbalance changes sign, while every squared term and the raw energy remain unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "complement-check",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Complement x = [1, 1, 1, 0, 1, 0] swaps A and B.\n",
+      "Complement energy: 28\n"
+     ]
+    }
+   ],
+   "source": [
+    "complement = complement_bits(representative)\n",
+    "complement_metrics = decoded_metrics(order_values, risk_exposures, complement)\n",
+    "complement_energy = order_partitioning_energy(\n",
+    "    order_values,\n",
+    "    risk_exposures,\n",
+    "    complement;\n",
+    "    a = value_weight,\n",
+    "    b = risk_weight,\n",
+    ")\n",
+    "\n",
+    "@assert complement in enumerated_optima\n",
+    "@assert complement_metrics.group_a == metrics.group_b\n",
+    "@assert complement_metrics.group_b == metrics.group_a\n",
+    "@assert complement_metrics.group_a_value == metrics.group_b_value\n",
+    "@assert complement_metrics.group_b_value == metrics.group_a_value\n",
+    "@assert complement_metrics.group_a_risk == metrics.group_b_risk\n",
+    "@assert complement_metrics.group_b_risk == metrics.group_a_risk\n",
+    "@assert complement_metrics.signed_value_imbalance == -metrics.signed_value_imbalance\n",
+    "@assert complement_metrics.signed_risk_imbalance == -metrics.signed_risk_imbalance\n",
+    "@assert complement_energy == enumerated_best_energy\n",
+    "\n",
+    "println(\"Complement x = $complement swaps A and B.\")\n",
+    "println(\"Complement energy: $(round(Int, complement_energy))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "weight-heading",
+   "metadata": {},
+   "source": [
+    "## Weight sensitivity\n",
+    "\n",
+    "Weights $a$ and $b$ express a modeling priority; they do not reveal one universally best partition. Increasing $a$ favors value balance, while increasing $b$ favors factor-risk balance. We enumerate the same fixture under three choices so that the trade-off is transparent rather than inferred from one solver run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "weight-sensitivity",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "case            a  b  |value A-B|  risk B-A  risk score  energy  representative x\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balanced         2  1            2  [2, 4]             20      28  [0, 0, 0, 1, 0, 1]\n",
+      "value priority   8  1            0  [2, -6]            40      40  [0, 1, 0, 1, 1, 0]\n",
+      "risk priority    1  8            6  [0, -2]             4      68  [0, 0, 0, 1, 1, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "function best_assignment_for_weights(states, values, exposures; a, b)\n",
+    "    energies = [\n",
+    "        order_partitioning_energy(values, exposures, bits; a = a, b = b)\n",
+    "        for bits in states\n",
+    "    ]\n",
+    "    best_energy = minimum(energies)\n",
+    "    optima = states[findall(==(best_energy), energies)]\n",
+    "    representative = first(filter(bits -> bits[1] == 0, optima))\n",
+    "    return best_energy, representative, optima\n",
+    "end\n",
+    "\n",
+    "weight_cases = [\n",
+    "    (label = \"balanced\", a = 2, b = 1),\n",
+    "    (label = \"value priority\", a = 8, b = 1),\n",
+    "    (label = \"risk priority\", a = 1, b = 8),\n",
+    "]\n",
+    "weight_results = [\n",
+    "    begin\n",
+    "        energy, bits, optima = best_assignment_for_weights(\n",
+    "            states,\n",
+    "            order_values,\n",
+    "            risk_exposures;\n",
+    "            a = case.a,\n",
+    "            b = case.b,\n",
+    "        )\n",
+    "        (\n",
+    "            label = case.label,\n",
+    "            a = case.a,\n",
+    "            b = case.b,\n",
+    "            energy = energy,\n",
+    "            bits = bits,\n",
+    "            value_imbalance = abs(signed_value_imbalance(order_values, bits)),\n",
+    "            risk_imbalances = risk_imbalances(risk_exposures, bits),\n",
+    "            risk_score = risk_term(risk_exposures, bits),\n",
+    "            degeneracy = length(optima),\n",
+    "        )\n",
+    "    end\n",
+    "    for case in weight_cases\n",
+    "]\n",
+    "\n",
+    "@assert weight_results[1].energy == 28\n",
+    "@assert weight_results[2].energy == 40\n",
+    "@assert weight_results[2].value_imbalance == 0\n",
+    "@assert weight_results[2].risk_score == 40\n",
+    "@assert weight_results[3].energy == 68\n",
+    "@assert weight_results[3].value_imbalance == 6\n",
+    "@assert weight_results[3].risk_score == 4\n",
+    "@assert all(result.degeneracy == 2 for result in weight_results)\n",
+    "\n",
+    "println(\"case            a  b  |value A-B|  risk B-A  risk score  energy  representative x\")\n",
+    "for result in weight_results\n",
+    "    @printf(\n",
+    "        \"%-15s %2d %2d %12d  %-10s %10d %7d  %s\\n\",\n",
+    "        result.label,\n",
+    "        result.a,\n",
+    "        result.b,\n",
+    "        result.value_imbalance,\n",
+    "        string(result.risk_imbalances),\n",
+    "        result.risk_score,\n",
+    "        result.energy,\n",
+    "        string(result.bits),\n",
+    "    )\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "weight-interpretation",
+   "metadata": {},
+   "source": [
+    "The value-priority case reaches equal group value but accepts a larger factor-risk score. The risk-priority case reduces the factor-risk score from 20 to 4 but accepts a value difference of six fixture units (USD 600,000). The balanced case lies between those outcomes. Appropriate weights depend on units, risk governance, and the purpose of the experiment; this tutorial does not prescribe them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "practice",
+   "metadata": {},
+   "source": [
+    "## Practice checkpoints\n",
+    "\n",
+    "1. Set $a=b=1$. Predict the optimal value and risk imbalances, then confirm them by enumerating all states.\n",
+    "2. Change the liquidity exposure of ORD-6 from 0 to 2. Before solving, identify which assertions must be recomputed and why hard-coded solver output is not a correctness proof.\n",
+    "3. Replace the grouped risk expression in a scratch model with the square-inside expression. Confirm that its risk contribution is identical for all 64 assignments, then restore the corrected model.\n",
+    "\n",
+    "For every change, rerun the all-state comparison before trusting the decoded result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "exercise-equal-weights",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE: start with a = b = 1 and reuse best_assignment_for_weights.\n",
+    "# Keep the exhaustive JuMP-versus-direct comparison as the acceptance check.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "solution-equal-weights",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equal weights: energy=24, x=[0, 0, 0, 1, 0, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "equal_weight_energy, equal_weight_bits, equal_weight_optima = best_assignment_for_weights(\n",
+    "    states,\n",
+    "    order_values,\n",
+    "    risk_exposures;\n",
+    "    a = 1,\n",
+    "    b = 1,\n",
+    ")\n",
+    "@assert equal_weight_energy == 24\n",
+    "@assert abs(signed_value_imbalance(order_values, equal_weight_bits)) == 2\n",
+    "@assert risk_term(risk_exposures, equal_weight_bits) == 20\n",
+    "@assert length(equal_weight_optima) == 2\n",
+    "println(\"Equal weights: energy=$equal_weight_energy, x=$equal_weight_bits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "exercise-exposure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE: change the liquidity exposure of ORD-6 from 0 to 2.\n",
+    "# Re-enumerate before making any claim about the new optimum.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "solution-exposure",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Changed exposure: energy=28, degeneracy=4, representative x=[0, 0, 1, 1, 1, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "changed_exposures = copy(risk_exposures)\n",
+    "changed_exposures[2, 6] = 2\n",
+    "changed_energy, changed_bits, changed_optima = best_assignment_for_weights(\n",
+    "    states,\n",
+    "    order_values,\n",
+    "    changed_exposures;\n",
+    "    a = value_weight,\n",
+    "    b = risk_weight,\n",
+    ")\n",
+    "@assert changed_energy == 28\n",
+    "@assert length(changed_optima) == 4\n",
+    "@assert all(\n",
+    "    order_partitioning_energy(\n",
+    "        order_values,\n",
+    "        changed_exposures,\n",
+    "        bits;\n",
+    "        a = value_weight,\n",
+    "        b = risk_weight,\n",
+    "    ) == changed_energy\n",
+    "    for bits in changed_optima\n",
+    ")\n",
+    "println(\"Changed exposure: energy=$changed_energy, degeneracy=$(length(changed_optima)), representative x=$changed_bits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "exercise-regression",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCISE: compare the grouped-square risk term with the square-inside term.\n",
+    "# Count the distinct values each expression takes across all 64 states.\n",
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "solution-regression",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "solution"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grouped square has 22 distinct values; square-inside has 1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SOLUTION (hidden in workshop version):\n",
+    "grouped_values = unique(risk_term(risk_exposures, bits) for bits in states)\n",
+    "square_inside_values = unique(\n",
+    "    incorrect_risk_term_square_inside(risk_exposures, bits) for bits in states\n",
+    ")\n",
+    "@assert length(grouped_values) > 1\n",
+    "@assert length(square_inside_values) == 1\n",
+    "println(\"Grouped square has $(length(grouped_values)) distinct values; square-inside has $(length(square_inside_values)).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "**Learning objectives met:**\n",
+    "\n",
+    "- Value balance and each factor-risk balance are squared only after summing signed order contributions.\n",
+    "- The independently constructed six-order fixture has a nonconstant risk term, unlike the square-inside regression witness.\n",
+    "- The direct formula and expanded JuMP objective agree for every assignment.\n",
+    "- ExactSampler and independent enumeration return the same two complementary global minima.\n",
+    "- Decoded group totals, factor exposures, signed and absolute imbalances, aggregate risk imbalance, and raw energy agree with direct calculations.\n",
+    "- Weight changes expose a real trade-off; no one pair of weights is universally best.\n",
+    "\n",
+    "**Next steps:** Later notebooks may compare local or hardware-oriented solvers, but those comparisons are intentionally outside this modeling case study.\n",
+    "\n",
+    "**Further reading:**\n",
+    "\n",
+    "- The Five Starter Problems paper motivates order partitioning and derives the grouped-square objective.\n",
+    "- The QUBO.jl documentation explains the JuMP modeling and exact-sampling interfaces used here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "references",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. A. R. Mazumder and S. Tayur, *Five Starter Problems: Solving Quadratic Unconstrained Binary Optimization Models on Quantum Computers*, TutORials in Operations Research (2025), pp. 145–183, https://doi.org/10.1287/educ.2025.0288.\n",
+    "2. Companion materials: https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers.\n",
+    "3. QUBO.jl public API and ExactSampler: https://github.com/JuliaQUBO/QUBO.jl.\n",
+    "\n",
+    "This notebook contains original Julia code, prose, and an independently constructed synthetic fixture. The companion repository is cited as context; no source cells, prose, saved output, figures, or other implementation material were copied from it. The example is educational and is not investment advice or an empirical trading result."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia",
+   "language": "julia",
+   "name": "julia"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ notebook_links = [
     "notebooks_py/5-Benchmarking_python.ipynb",
     "notebooks_py/6-QCi_python.ipynb",
     "notebooks_jl/7-CanonicalProblems.ipynb",
+    "notebooks_jl/8-OrderPartitioning.ipynb",
 ]
 files_with_repository_links = [
     "README.md",

--- a/tests/test_order_partitioning_notebook.py
+++ b/tests/test_order_partitioning_notebook.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import itertools
+import json
+import math
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "8-OrderPartitioning.ipynb"
+
+
+def notebook() -> dict:
+    return json.loads(NOTEBOOK_PATH.read_text())
+
+
+def notebook_source() -> str:
+    return "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook()["cells"]
+    )
+
+
+def notebook_cell(data: dict, cell_id: str) -> dict:
+    matches = [cell for cell in data["cells"] if cell.get("id") == cell_id]
+    if len(matches) != 1:
+        raise AssertionError(f"Expected one cell with id {cell_id!r}, found {len(matches)}")
+    return matches[0]
+
+
+def cell_output_text(cell: dict) -> str:
+    output_parts = []
+    for output in cell.get("outputs", []):
+        value = output.get("text", output.get("data", {}).get("text/plain", ""))
+        output_parts.append("".join(value) if isinstance(value, list) else value)
+    return "\n".join(output_parts)
+
+
+def binary_states(size: int) -> list[tuple[int, ...]]:
+    return list(itertools.product((0, 1), repeat=size))
+
+
+ORDER_VALUES = (2, 3, 4, 5, 6, 8)
+RISK_EXPOSURES = (
+    (1, 1, 2, 5, 4, 5),
+    (4, -2, 3, 6, -3, 0),
+)
+
+
+def value_imbalance(bits: tuple[int, ...]) -> int:
+    return sum(
+        value * (1 - 2 * bit) for value, bit in zip(ORDER_VALUES, bits)
+    )
+
+
+def risk_imbalances(bits: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(
+        sum(exposure * (2 * bit - 1) for exposure, bit in zip(row, bits))
+        for row in RISK_EXPOSURES
+    )
+
+
+def direct_energy(bits: tuple[int, ...], *, a: int = 2, b: int = 1) -> int:
+    return a * value_imbalance(bits) ** 2 + b * sum(
+        imbalance**2 for imbalance in risk_imbalances(bits)
+    )
+
+
+def expanded_energy(bits: tuple[int, ...], *, a: int = 2, b: int = 1) -> int:
+    total_value = sum(ORDER_VALUES)
+    constant = a * total_value**2
+    linear = sum(
+        a * (4 * value**2 - 4 * total_value * value) * bits[j]
+        for j, value in enumerate(ORDER_VALUES)
+    )
+    quadratic = sum(
+        8 * a * ORDER_VALUES[j] * ORDER_VALUES[k] * bits[j] * bits[k]
+        for j in range(len(bits))
+        for k in range(j + 1, len(bits))
+    )
+
+    for row in RISK_EXPOSURES:
+        total_exposure = sum(row)
+        constant += b * total_exposure**2
+        linear += sum(
+            b * (4 * exposure**2 - 4 * total_exposure * exposure) * bits[j]
+            for j, exposure in enumerate(row)
+        )
+        quadratic += sum(
+            8 * b * row[j] * row[k] * bits[j] * bits[k]
+            for j in range(len(bits))
+            for k in range(j + 1, len(bits))
+        )
+
+    return constant + linear + quadratic
+
+
+class OrderPartitioningNotebookSourceTests(unittest.TestCase):
+    def test_notebook_has_required_tutorial_structure_and_scope(self) -> None:
+        source = notebook_source()
+        required_markers = (
+            "## Setup",
+            "## Learning objectives",
+            "## Prerequisites",
+            "## Order-partitioning model",
+            "## Exact verification",
+            "## Decoded balances",
+            "## Complement symmetry",
+            "## Weight sensitivity",
+            "## Practice checkpoints",
+            "## Summary",
+            "## References",
+            "https://doi.org/10.1287/educ.2025.0288",
+            "https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers",
+            "not investment advice",
+            "original Julia code",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, source)
+
+        for out_of_scope_marker in ("DWave", "QAOA", "API key", "token"):
+            with self.subTest(out_of_scope_marker=out_of_scope_marker):
+                self.assertNotIn(out_of_scope_marker, source)
+
+    def test_model_places_each_square_outside_the_order_sum(self) -> None:
+        data = notebook()
+        model_source = "".join(notebook_cell(data, "qubo-model")["source"])
+
+        grouped_square = (
+            "(sum(risk_exposures[i, j] * (2 * order_x[j] - 1) "
+            "for j in 1:n_orders))^2"
+        )
+        misplaced_square = "risk_exposures[i, j] * (2 * order_x[j] - 1)^2"
+
+        self.assertIn(grouped_square, model_source)
+        self.assertNotIn(misplaced_square, model_source)
+        self.assertIn("incorrect_risk_term_square_inside", notebook_source())
+
+    def test_notebook_uses_public_local_exact_solver_and_exhaustive_checks(self) -> None:
+        source = notebook_source()
+        required_markers = (
+            "QUBO.ExactSampler.Optimizer",
+            "all_binary_states(n_orders)",
+            "evaluate_jump_objective",
+            "order_partitioning_energy",
+            "length(states) == 64",
+            "length(unique(correct_risk_terms)) > 1",
+            "length(unique(incorrect_risk_terms)) == 1",
+            "same_states(exact_optima, enumerated_optima)",
+            "complement_bits",
+            "decoded_metrics",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, source)
+
+    def test_notebook_commits_reproducible_outputs(self) -> None:
+        data = notebook()
+        code_cells = [cell for cell in data["cells"] if cell["cell_type"] == "code"]
+
+        self.assertTrue(code_cells)
+        self.assertEqual(
+            list(range(1, len(code_cells) + 1)),
+            [cell.get("execution_count") for cell in code_cells],
+        )
+        self.assertEqual([], notebook_cell(data, "bootstrap").get("outputs", []))
+        self.assertEqual([], notebook_cell(data, "activate").get("outputs", []))
+
+        expected_output_markers = {
+            "all-state-check": "All 64 assignments match the direct grouped-square formula.",
+            "exact-check": "Enumerated optimum energy: 28",
+            "decoded-balance": "Group A total: $1.5M",
+            "complement-check": "Complement energy: 28",
+            "weight-sensitivity": "risk priority",
+        }
+        for cell_id, marker in expected_output_markers.items():
+            with self.subTest(cell_id=cell_id):
+                self.assertIn(marker, cell_output_text(notebook_cell(data, cell_id)))
+
+        self.assertFalse(
+            any(
+                output.get("output_type") == "error"
+                for cell in code_cells
+                for output in cell.get("outputs", [])
+            )
+        )
+
+        serialized_outputs = json.dumps(
+            [cell.get("outputs", []) for cell in code_cells], ensure_ascii=False
+        )
+        for marker in ("/home/", "/Users/", "C:\\Users", "AppData", "Bearer "):
+            with self.subTest(forbidden_output_marker=marker):
+                self.assertNotIn(marker, serialized_outputs)
+
+    def test_notebook_and_target_are_linked(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text()
+        makefile = (REPO_ROOT / "Makefile").read_text()
+
+        self.assertIn("notebooks_jl/8-OrderPartitioning.ipynb", readme)
+        self.assertIn("make verify-order-partitioning-julia", readme)
+        self.assertIn("verify-order-partitioning-julia:", makefile)
+        self.assertIn(
+            'NOTEBOOKS="$(ORDER_PARTITIONING_JULIA_NOTEBOOK)"', makefile
+        )
+
+
+class OrderPartitioningMathematicalInvariantTests(unittest.TestCase):
+    def test_expanded_qubo_matches_direct_formula_for_all_assignments(self) -> None:
+        states = binary_states(len(ORDER_VALUES))
+
+        self.assertEqual(64, len(states))
+        self.assertTrue(
+            all(expanded_energy(bits) == direct_energy(bits) for bits in states)
+        )
+
+    def test_risk_regression_and_complement_symmetry(self) -> None:
+        states = binary_states(len(ORDER_VALUES))
+        correct_risk_terms = {
+            sum(imbalance**2 for imbalance in risk_imbalances(bits))
+            for bits in states
+        }
+        misplaced_square_terms = {
+            sum(
+                exposure * (2 * bit - 1) ** 2
+                for row in RISK_EXPOSURES
+                for exposure, bit in zip(row, bits)
+            )
+            for bits in states
+        }
+
+        self.assertGreater(len(correct_risk_terms), 1)
+        self.assertEqual(1, len(misplaced_square_terms))
+        self.assertTrue(
+            all(
+                direct_energy(bits)
+                == direct_energy(tuple(1 - bit for bit in bits))
+                for bits in states
+            )
+        )
+
+    def test_exact_optimum_and_decoded_metrics(self) -> None:
+        states = binary_states(len(ORDER_VALUES))
+        optimum = min(direct_energy(bits) for bits in states)
+        optima = {bits for bits in states if direct_energy(bits) == optimum}
+
+        self.assertEqual(28, optimum)
+        self.assertEqual(
+            {(0, 0, 0, 1, 0, 1), (1, 1, 1, 0, 1, 0)}, optima
+        )
+
+        representative = (0, 0, 0, 1, 0, 1)
+        group_a = [j for j, bit in enumerate(representative) if bit == 0]
+        group_b = [j for j, bit in enumerate(representative) if bit == 1]
+        value_a = sum(ORDER_VALUES[j] for j in group_a)
+        value_b = sum(ORDER_VALUES[j] for j in group_b)
+        risk_a = tuple(sum(row[j] for j in group_a) for row in RISK_EXPOSURES)
+        risk_b = tuple(sum(row[j] for j in group_b) for row in RISK_EXPOSURES)
+
+        self.assertEqual((15, 13), (value_a, value_b))
+        self.assertEqual((8, 2), risk_a)
+        self.assertEqual((10, 6), risk_b)
+        self.assertEqual((2, 4), risk_imbalances(representative))
+        self.assertTrue(math.isclose(math.sqrt(20), math.dist(risk_a, risk_b)))
+
+    def test_weight_sensitivity_exposes_the_tradeoff(self) -> None:
+        states = binary_states(len(ORDER_VALUES))
+
+        def optima(a: int, b: int) -> tuple[int, set[tuple[int, ...]]]:
+            best = min(direct_energy(bits, a=a, b=b) for bits in states)
+            return best, {
+                bits for bits in states if direct_energy(bits, a=a, b=b) == best
+            }
+
+        value_energy, value_optima = optima(8, 1)
+        risk_energy, risk_optima = optima(1, 8)
+
+        self.assertEqual(40, value_energy)
+        self.assertEqual(
+            {(0, 1, 0, 1, 1, 0), (1, 0, 1, 0, 0, 1)}, value_optima
+        )
+        self.assertTrue(all(value_imbalance(bits) == 0 for bits in value_optima))
+
+        self.assertEqual(68, risk_energy)
+        self.assertEqual(
+            {(0, 0, 0, 1, 1, 0), (1, 1, 1, 0, 0, 1)}, risk_optima
+        )
+        self.assertTrue(
+            all(sum(value**2 for value in risk_imbalances(bits)) == 4 for bits in risk_optima)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -29,6 +29,9 @@ BENCHMARKING_PYTHON_NOTEBOOK_PATH = (
 CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH = (
     REPO_ROOT / "notebooks_jl" / "7-CanonicalProblems.ipynb"
 )
+ORDER_PARTITIONING_JULIA_NOTEBOOK_PATH = (
+    REPO_ROOT / "notebooks_jl" / "8-OrderPartitioning.ipynb"
+)
 BENCHMARKING_RESULTS_ARCHIVES = (
     REPO_ROOT / "notebooks_py" / "results.zip",
     REPO_ROOT / "notebooks_jl" / "results.zip",
@@ -40,6 +43,7 @@ JULIA_COLAB_NOTEBOOK_PATHS = (
     REPO_ROOT / "notebooks_jl" / "4-DWave.ipynb",
     REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb",
     CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH,
+    ORDER_PARTITIONING_JULIA_NOTEBOOK_PATH,
 )
 BOOTSTRAP_PATH = REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
 NOTEBOOK_DIRS = (


### PR DESCRIPTION
## Summary

- add an original Julia order-partitioning case study with a six-order synthetic USD/risk fixture
- implement the published grouped-square value and factor-risk objective directly in JuMP/QUBO.jl
- exhaustively compare all 64 JuMP objective values with an independent formula, verify complement symmetry, and match ExactSampler to the enumerated global minima
- decode both A/B groups, report value and factor-risk balances, and demonstrate value-versus-risk weight sensitivity
- add a dedicated verification target, README navigation, notebook inventories, and focused regression tests

## Correctness and provenance

- The risk square encloses the order sum for each factor; a named square-inside regression witness is proven constant over all assignments.
- The committed notebook outputs were regenerated from a clean Julia 1.10.11 kernel with no credentials, external data, or solver service.
- The fixture, Julia code, prose, and outputs are original. The paper and its unlicensed companion repository are cited as context; no implementation material was copied.

## Verification

- `make verify-order-partitioning-julia`
- `make test-python PYTHON=.venv/bin/python` (118 tests)
- `make test-julia` (84 checks)
- `make test`
- `make check-notebook-output-hygiene`
- `uv lock --check --cache-dir .uv-cache`
- mutation check: moving the model's risk square inside the order sum makes the focused source regression fail

## Branch Hygiene

- Base branch: `main`
- Source branch point: `b17fd252933603048f7b267987b76fe328994f8a`
- Source branch: `codex/issue-93-order-partitioning`
- Not stacked; no prerequisite PRs
- Open PR #89 changes only `pyproject.toml` and `uv.lock`, so it has no overlapping files or hunks

## Coordination

- Closes #93 and advances parent roadmap #90.
- Uses the merged #92 notebook as a structural precedent only.
- Solver comparisons and the remaining roadmap notebooks stay with #94-#97.

Closes #93
