### PR TITLE
Add reproducible Julia cancer-genomics case study

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-canonical-problems-julia verify-order-partitioning-julia
+.PHONY: test sysimage test-python test-julia check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-canonical-problems-julia verify-order-partitioning-julia verify-cancer-genomics-julia
 
 PYTHON ?= python3
 UV ?= uv
@@ -16,6 +16,7 @@ DWAVE_PYTHON_NOTEBOOK ?= notebooks_py/4-DWAVE_python.ipynb
 BENCHMARKING_PYTHON_NOTEBOOK ?= notebooks_py/5-Benchmarking_python.ipynb
 CANONICAL_PROBLEMS_JULIA_NOTEBOOK ?= notebooks_jl/7-CanonicalProblems.ipynb
 ORDER_PARTITIONING_JULIA_NOTEBOOK ?= notebooks_jl/8-OrderPartitioning.ipynb
+CANCER_GENOMICS_JULIA_NOTEBOOK ?= notebooks_jl/9-CancerGenomics.ipynb
 NOTEBOOKS ?= $(PORTABLE_PYTHON_NOTEBOOKS)
 NOTEBOOK_FILES ?= notebooks_jl/*.ipynb notebooks_py/*.ipynb
 
@@ -74,3 +75,6 @@ verify-canonical-problems-julia:
 
 verify-order-partitioning-julia:
 	$(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(ORDER_PARTITIONING_JULIA_NOTEBOOK)"
+
+verify-cancer-genomics-julia:
+	$(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(CANCER_GENOMICS_JULIA_NOTEBOOK)"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ long benchmark runs.
 | QCi | Not available | [notebooks_py/6-QCi_python.ipynb](notebooks_py/6-QCi_python.ipynb) | Requires QCi API credentials and the QCi Python stack. |
 | Canonical QUBO starter problems | [notebooks_jl/7-CanonicalProblems.ipynb](notebooks_jl/7-CanonicalProblems.ipynb) | Not available | Credential-free Julia notebook covered by `make verify-canonical-problems-julia`; exhaustive checks validate number partitioning, Max-Cut, and minimum vertex cover. |
 | Order partitioning for A/B testing | [notebooks_jl/8-OrderPartitioning.ipynb](notebooks_jl/8-OrderPartitioning.ipynb) | Not available | Credential-free Julia notebook covered by `make verify-order-partitioning-julia`; all 64 assignments validate the grouped value/risk objective and decoded balances. |
+| Altered cancer pathways from TCGA AML aggregates | [notebooks_jl/9-CancerGenomics.ipynb](notebooks_jl/9-CancerGenomics.ipynb) | Not available | Offline, credential-free Julia notebook covered by `make verify-cancer-genomics-julia`; a tiny incidence fixture is solved exhaustively and a seeded local sampler validates the committed aggregate without claiming clinical significance. |
 
 ## Local verification
 
@@ -66,6 +67,7 @@ make verify-qubo-python
 make verify-gama-python
 make verify-canonical-problems-julia
 make verify-order-partitioning-julia
+make verify-cancer-genomics-julia
 ```
 
 The generic verifier can execute selected notebooks by overriding `NOTEBOOKS`

--- a/notebooks_jl/9-CancerGenomics.ipynb
+++ b/notebooks_jl/9-CancerGenomics.ipynb
@@ -1,0 +1,1239 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "title",
+      "metadata": {},
+      "source": [
+        "<a name=\"top\" id=\"top\"></a>\n",
+        "\n",
+        "<div align=\"center\">\n",
+        "  <h1>Altered Cancer Pathways from Reproducible TCGA AML Aggregates</h1>\n",
+        "  <p>An original Julia case study balancing mutation coverage and pairwise co-mutation.</p>\n",
+        "  <a href=\"https://colab.research.google.com/github/JuliaQUBO/QUBONotebooks/blob/main/notebooks_jl/9-CancerGenomics.ipynb\" target=\"_parent\">\n",
+        "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "  </a>\n",
+        "</div>\n",
+        "\n",
+        "> **Educational use only.** This notebook reproduces an optimization formulation on a fixed public-data aggregate. It does not identify a clinically validated pathway and is not medical guidance.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "setup",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "### Local installation\n",
+        "\n",
+        "From the repository root, instantiate the shared Julia environment before opening this notebook:\n",
+        "\n",
+        "    julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
+        "\n",
+        "Restart the kernel and run every cell with the targeted command:\n",
+        "\n",
+        "    make verify-cancer-genomics-julia\n",
+        "\n",
+        "Ordinary execution reads only the committed files under notebooks_data. It requires no account, credential, live data request, or quantum service. The optional make refresh-tcga-aml maintenance command is documented in notebooks_data/README.md and is not run here.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "colab",
+      "metadata": {},
+      "source": [
+        "### Google Colab\n",
+        "\n",
+        "Open the badge above, select a Julia runtime, and run the setup cells. The bootstrap clones this repository only when Colab does not already have it, then activates the same checked-in notebook project and reads the same committed aggregate.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "bootstrap",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "function load_qubonotebooks_bootstrap()\n",
+        "    candidates = (\n",
+        "        joinpath(pwd(), \"scripts\", \"notebook_bootstrap.jl\"),\n",
+        "        joinpath(pwd(), \"..\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+        "        joinpath(pwd(), \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+        "        joinpath(\"/content\", \"QUBONotebooks\", \"scripts\", \"notebook_bootstrap.jl\"),\n",
+        "    )\n",
+        "\n",
+        "    for candidate in candidates\n",
+        "        if isfile(candidate)\n",
+        "            include(candidate)\n",
+        "            return nothing\n",
+        "        end\n",
+        "    end\n",
+        "\n",
+        "    in_colab = haskey(ENV, \"COLAB_RELEASE_TAG\") || haskey(ENV, \"COLAB_JUPYTER_IP\") || isdir(joinpath(\"/content\", \"sample_data\"))\n",
+        "    if in_colab\n",
+        "        repo_dir = get(ENV, \"QUBONOTEBOOKS_REPO_DIR\", joinpath(pwd(), \"QUBONotebooks\"))\n",
+        "        if !isdir(repo_dir)\n",
+        "            println(\"[bootstrap] Cloning JuliaQUBO/QUBONotebooks into $repo_dir\")\n",
+        "            run(Cmd([\"git\", \"clone\", \"--depth\", \"1\", \"https://github.com/JuliaQUBO/QUBONotebooks.git\", repo_dir]))\n",
+        "        end\n",
+        "        include(joinpath(repo_dir, \"scripts\", \"notebook_bootstrap.jl\"))\n",
+        "        return nothing\n",
+        "    end\n",
+        "\n",
+        "    error(\"Could not locate scripts/notebook_bootstrap.jl from $(pwd()).\")\n",
+        "end\n",
+        "\n",
+        "load_qubonotebooks_bootstrap()\n",
+        "\n",
+        "BOOTSTRAP = Base.invokelatest(QUBONotebooksBootstrap.bootstrap_notebook, \"9-CancerGenomics\")\n",
+        "QUBONOTEBOOKS_REPO_DIR = BOOTSTRAP.repo_dir\n",
+        "JULIA_NOTEBOOKS_DIR = BOOTSTRAP.notebooks_dir\n",
+        "JULIA_PROJECT_DIR = BOOTSTRAP.project_dir\n",
+        "IN_COLAB = BOOTSTRAP.in_colab\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "activate",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import Pkg\n",
+        "\n",
+        "python_warning_filter = \"ignore:invalid escape sequence:SyntaxWarning\"\n",
+        "python_warning_filters = String.(filter(!isempty, split(get(ENV, \"PYTHONWARNINGS\", \"\"), \",\")))\n",
+        "if python_warning_filter ∉ python_warning_filters\n",
+        "    push!(python_warning_filters, python_warning_filter)\n",
+        "    ENV[\"PYTHONWARNINGS\"] = join(python_warning_filters, \",\")\n",
+        "end\n",
+        "\n",
+        "if @isdefined(JULIA_PROJECT_DIR)\n",
+        "    Pkg.activate(JULIA_PROJECT_DIR)\n",
+        "else\n",
+        "    Pkg.activate(@__DIR__)\n",
+        "end\n",
+        "Pkg.instantiate(; io = devnull)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "objectives",
+      "metadata": {},
+      "source": [
+        "## Learning objectives\n",
+        "\n",
+        "By the end of this notebook you will be able to:\n",
+        "\n",
+        "1. construct coverage and symmetric co-mutation matrices from a patient-by-gene incidence matrix;\n",
+        "2. explain the double-counting convention in the matrix QUBO;\n",
+        "3. exhaustively verify a tiny fixture against an independent analytic energy;\n",
+        "4. decode coverage, distinct-patient coverage, co-mutation, pathway size, and raw energy safely; and\n",
+        "5. run and validate a seeded local sampler on a provenance-checked TCGA AML aggregate.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "prerequisites",
+      "metadata": {},
+      "source": [
+        "## Prerequisites\n",
+        "\n",
+        "**Prior notebooks:** Notebook 2 introduces JuMP/QUBO models, and Notebook 7 develops exhaustive verification. This case study defines the helpers it needs so it remains independently runnable.\n",
+        "\n",
+        "**Mathematical background:** Binary incidence matrices, matrix multiplication, quadratic objectives, and finite enumeration.\n",
+        "\n",
+        "**Data background:** The committed TCGA AML files are gene-level reproducibility aggregates, not raw clinical records. Patient and sample identifiers are intentionally absent.\n",
+        "\n",
+        "**Software and accounts:** Julia 1.10+ with the shared notebook project instantiated. No external account is required.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "imports",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "using DWave\n",
+        "using JSON\n",
+        "using JuMP\n",
+        "using LinearAlgebra\n",
+        "using Printf\n",
+        "using QUBO\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "incidence-heading",
+      "metadata": {},
+      "source": [
+        "## From incidence data to coverage and co-mutation\n",
+        "\n",
+        "Let rows of the binary matrix $B$ represent patients or samples and columns represent genes. An entry $B_{p,g}=1$ means gene $g$ is observed as mutated for patient $p$. The cited formulation uses the transposed orientation (genes by patients); either convention produces the same gene-by-gene Gram matrix when used consistently.\n",
+        "\n",
+        "We start with seven synthetic patients and four synthetic genes. The fixture is deliberately small enough to inspect without biological interpretation.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "tiny-fixture",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Tiny fixture: 7 patients × 4 genes\n"
+          ]
+        }
+      ],
+      "source": [
+        "tiny_patients = [\"P1\", \"P2\", \"P3\", \"P4\", \"P5\", \"P6\", \"P7\"]\n",
+        "tiny_genes = [\"G-A\", \"G-B\", \"G-C\", \"G-D\"]\n",
+        "tiny_B = Int[\n",
+        "    1  1  0  0\n",
+        "    1  0  0  0\n",
+        "    1  0  0  0\n",
+        "    0  1  0  0\n",
+        "    0  0  1  1\n",
+        "    0  0  1  0\n",
+        "    0  0  0  1\n",
+        "]\n",
+        "\n",
+        "@assert size(tiny_B) == (length(tiny_patients), length(tiny_genes))\n",
+        "@assert all(value in (0, 1) for value in tiny_B)\n",
+        "println(\"Tiny fixture: $(size(tiny_B, 1)) patients × $(size(tiny_B, 2)) genes\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "derive-explanation",
+      "metadata": {},
+      "source": [
+        "For each gene, the coverage value is the number of patients containing that gene. The diagonal matrix $D$ stores those counts. For each pair $i<j$, $A_{ij}$ is the number of patients containing both genes. We assign both $A_{ij}$ and $A_{ji}$, and leave the diagonal at zero. Thus\n",
+        "\n",
+        "$$\n",
+        "B^{\\mathsf{T}}B = D + A.\n",
+        "$$\n",
+        "\n",
+        "The explicit pair loop below prevents the stale-index defect found in the companion notebooks.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "matrix-helpers",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "coverage_and_comutation"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "\"\"\"\n",
+        "    coverage_and_comutation(B)\n",
+        "\n",
+        "Return the per-gene coverage vector and zero-diagonal symmetric co-mutation\n",
+        "matrix for a binary patient-by-gene incidence matrix.\n",
+        "\"\"\"\n",
+        "function coverage_and_comutation(B::AbstractMatrix{<:Integer})\n",
+        "    @assert all(value in (0, 1) for value in B)\n",
+        "    n_genes = size(B, 2)\n",
+        "    coverage = vec(sum(B; dims = 1))\n",
+        "    A = zeros(Int, n_genes, n_genes)\n",
+        "\n",
+        "    for i in 1:(n_genes - 1)\n",
+        "        for j in (i + 1):n_genes\n",
+        "            overlap = sum(B[:, i] .* B[:, j])\n",
+        "            A[i, j] = overlap\n",
+    "            A[j, i] = overlap\n",
+        "        end\n",
+        "    end\n",
+        "\n",
+        "    return coverage, A\n",
+        "end\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "tiny-matrices",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "D diagonal = [3, 2, 2, 2]\n",
+            "A =\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "4×4 Matrix{Int64}:\n",
+              " 0  1  0  0\n",
+              " 1  0  0  0\n",
+              " 0  0  0  1\n",
+              " 0  0  1  0"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "tiny_coverage, tiny_A = coverage_and_comutation(tiny_B)\n",
+        "tiny_D = Diagonal(tiny_coverage)\n",
+        "tiny_gram = tiny_B' * tiny_B\n",
+        "expected_tiny_A = Int[\n",
+        "    0  1  0  0\n",
+        "    1  0  0  0\n",
+        "    0  0  0  1\n",
+        "    0  0  1  0\n",
+        "]\n",
+        "\n",
+        "@assert tiny_coverage == [3, 2, 2, 2]\n",
+        "@assert tiny_A == expected_tiny_A\n",
+        "@assert tiny_A == tiny_A'\n",
+        "@assert iszero(diag(tiny_A))\n",
+        "@assert tiny_gram == tiny_D + tiny_A\n",
+        "\n",
+        "println(\"D diagonal = $tiny_coverage\")\n",
+        "println(\"A =\")\n",
+        "display(tiny_A)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "qubo-formula",
+      "metadata": {},
+      "source": [
+        "## Build and interpret the QUBO\n",
+        "\n",
+        "For binary $x_g$, where one selects gene $g$, the tutorial model is\n",
+        "\n",
+        "$$\n",
+        "Q(x)=x^{\\mathsf{T}}(A-\\alpha D)x\n",
+        "    = 2\\sum_{i<j}A_{ij}x_ix_j-\\alpha\\sum_iD_{ii}x_i.\n",
+        "$$\n",
+        "\n",
+        "The negative diagonal term rewards gene coverage. The positive off-diagonal term penalizes pairwise co-mutation. Because $A$ is symmetric, $x^{\\mathsf{T}}Ax$ intentionally counts each undirected gene pair twice; code, analytic energy, and reported metrics all use that convention.\n",
+        "\n",
+        "The named parameter $\\alpha$ controls the modeling trade-off. It is not a confidence score and does not make the sampled genes clinically meaningful.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "metric-helpers",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "validate_decoded_metrics (generic function with 1 method)"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "function all_binary_states(n::Integer)\n",
+        "    return [\n",
+        "        collect(state)\n",
+        "        for state in Iterators.product(ntuple(_ -> (0, 1), n)...)\n",
+        "    ]\n",
+        "end\n",
+        "\n",
+        "function pathway_energy(coverage, A, bits; alpha)\n",
+        "    @assert alpha >= 0\n",
+        "    @assert length(coverage) == size(A, 1) == size(A, 2) == length(bits)\n",
+        "    return dot(bits, A * bits) - alpha * dot(coverage, bits)\n",
+        "end\n",
+        "\n",
+        "function distinct_patient_coverage_bounds(coverage, A, selected, patient_count)\n",
+        "    isempty(selected) && return (lower = 0, upper = 0)\n",
+        "\n",
+        "    coverage_sum = sum(coverage[selected])\n",
+        "    pairwise_overlap = sum(A[i, j] for i in selected for j in selected if i < j)\n",
+        "    lower = max(maximum(coverage[selected]), coverage_sum - pairwise_overlap)\n",
+        "    upper = min(patient_count, coverage_sum)\n",
+        "\n",
+        "    @assert 0 <= lower <= upper <= patient_count\n",
+        "    return (lower = lower, upper = upper)\n",
+        "end\n",
+        "\n",
+        "\"\"\"\n",
+        "    decoded_pathway_metrics(gene_names, coverage, A, bits; incidence=nothing, patient_count)\n",
+        "\n",
+        "Decode a pathway without dividing by the selected size or overlap count. Exact\n",
+        "distinct-patient coverage is returned only when an incidence matrix is present;\n",
+        "otherwise the aggregate supports rigorous Bonferroni lower and upper bounds.\n",
+        "\"\"\"\n",
+        "function decoded_pathway_metrics(\n",
+        "    gene_names,\n",
+        "    coverage,\n",
+        "    A,\n",
+        "    bits;\n",
+        "    incidence = nothing,\n",
+        "    patient_count,\n",
+        ")\n",
+        "    selected = findall(==(1), bits)\n",
+        "    pathway_size = length(selected)\n",
+        "    coverage_sum = sum(coverage[selected])\n",
+        "    pairwise_comutation = sum(\n",
+        "        (A[i, j] for i in selected for j in selected if i < j);\n",
+        "        init = 0,\n",
+        "    )\n",
+        "    double_counted_comutation = dot(bits, A * bits)\n",
+        "    pair_count = pathway_size * (pathway_size - 1) ÷ 2\n",
+        "    zero_comutation_pairs = count(\n",
+        "        A[i, j] == 0 for i in selected for j in selected if i < j\n",
+        "    )\n",
+        "    zero_comutation_pair_fraction =\n",
+        "        pair_count == 0 ? missing : zero_comutation_pairs / pair_count\n",
+        "\n",
+        "    if isnothing(incidence)\n",
+        "        exact_unique_coverage = missing\n",
+        "        unique_coverage_bounds = distinct_patient_coverage_bounds(\n",
+        "            coverage,\n",
+        "            A,\n",
+        "            selected,\n",
+        "            patient_count,\n",
+        "        )\n",
+        "    else\n",
+        "        @assert size(incidence, 2) == length(gene_names)\n",
+        "        exact_unique_coverage = isempty(selected) ? 0 : count(\n",
+        "            >(0),\n",
+        "            vec(sum(incidence[:, selected]; dims = 2)),\n",
+        "        )\n",
+        "        unique_coverage_bounds = (\n",
+        "            lower = exact_unique_coverage,\n",
+        "            upper = exact_unique_coverage,\n",
+        "        )\n",
+        "    end\n",
+        "\n",
+        "    @assert double_counted_comutation == 2 * pairwise_comutation\n",
+        "\n",
+        "    return (\n",
+        "        selected_indices = selected,\n",
+        "        selected_genes = gene_names[selected],\n",
+        "        pathway_size = pathway_size,\n",
+        "        coverage_sum = coverage_sum,\n",
+        "        exact_unique_coverage = exact_unique_coverage,\n",
+        "        unique_coverage_bounds = unique_coverage_bounds,\n",
+        "        pairwise_comutation = pairwise_comutation,\n",
+        "        double_counted_comutation = double_counted_comutation,\n",
+        "        zero_comutation_pair_fraction = zero_comutation_pair_fraction,\n",
+        "    )\n",
+        "end\n",
+        "\n",
+        "function validate_decoded_metrics(metrics, coverage, A, bits; patient_count)\n",
+        "    @assert metrics.selected_indices == findall(==(1), bits)\n",
+        "    @assert metrics.pathway_size == sum(bits)\n",
+        "    @assert metrics.coverage_sum == dot(coverage, bits)\n",
+        "    @assert metrics.double_counted_comutation == dot(bits, A * bits)\n",
+        "    @assert metrics.double_counted_comutation == 2 * metrics.pairwise_comutation\n",
+        "    @assert 0 <= metrics.unique_coverage_bounds.lower <=\n",
+        "        metrics.unique_coverage_bounds.upper <= patient_count\n",
+        "    if !ismissing(metrics.exact_unique_coverage)\n",
+        "        @assert metrics.unique_coverage_bounds.lower ==\n",
+        "            metrics.exact_unique_coverage ==\n",
+        "            metrics.unique_coverage_bounds.upper\n",
+        "    end\n",
+        "    return true\n",
+        "end\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "model-helpers",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "same_states (generic function with 1 method)"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "function build_pathway_model(coverage, A; alpha)\n",
+        "    @assert alpha >= 0\n",
+        "    @assert length(coverage) == size(A, 1) == size(A, 2)\n",
+        "    @assert A == A'\n",
+        "    @assert iszero(diag(A))\n",
+        "\n",
+        "    model = Model()\n",
+        "    @variable(model, pathway_x[1:length(coverage)], Bin)\n",
+        "    @objective(\n",
+        "        model,\n",
+        "        Min,\n",
+        "        sum(\n",
+        "            A[i, j] * pathway_x[i] * pathway_x[j]\n",
+        "            for i in eachindex(coverage), j in eachindex(coverage)\n",
+        "        ) - alpha * sum(\n",
+        "            coverage[i] * pathway_x[i] for i in eachindex(coverage)\n",
+        "        ),\n",
+        "    )\n",
+        "    return model, pathway_x\n",
+        "end\n",
+        "\n",
+        "function evaluate_jump_objective(model::Model, variables, bits)\n",
+        "    assignment = Dict(variables[i] => Float64(bits[i]) for i in eachindex(variables))\n",
+        "    return JuMP.value(variable -> assignment[variable], JuMP.objective_function(model))\n",
+        "end\n",
+        "\n",
+        "function exact_sampler_optima!(model::Model, variables; atol = 1e-9)\n",
+        "    set_optimizer(model, QUBO.ExactSampler.Optimizer)\n",
+        "    optimize!(model)\n",
+        "    @assert termination_status(model) in (JuMP.MOI.OPTIMAL, JuMP.MOI.LOCALLY_SOLVED)\n",
+        "\n",
+        "    energies = [objective_value(model; result = result) for result in 1:result_count(model)]\n",
+        "    best_energy = minimum(energies)\n",
+        "    optima = [\n",
+        "        round.(Int, value.(variables; result = result))\n",
+        "        for result in eachindex(energies)\n",
+        "        if isapprox(energies[result], best_energy; atol = atol, rtol = 0)\n",
+        "    ]\n",
+        "    return best_energy, optima\n",
+        "end\n",
+        "\n",
+        "same_states(left, right) = Set(Tuple.(left)) == Set(Tuple.(right))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "tiny-model",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tiny_alpha = 0.75\n",
+        "tiny_model, tiny_x = build_pathway_model(tiny_coverage, tiny_A; alpha = tiny_alpha)\n",
+        "nothing\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "exhaustive-heading",
+      "metadata": {},
+      "source": [
+        "## Exhaustive validation on the tiny fixture\n",
+        "\n",
+        "Four genes give $2^4=16$ assignments. For every state, we compare the JuMP objective against the independent matrix calculation and against the explicit pairwise expansion. This proves the factor-of-two convention before any sampler is trusted.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "all-state-check",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "All 16 assignments match the analytic matrix and explicit pairwise energies.\n"
+          ]
+        }
+      ],
+      "source": [
+        "tiny_states = all_binary_states(length(tiny_genes))\n",
+        "tiny_jump_energies = [\n",
+        "    evaluate_jump_objective(tiny_model, tiny_x, bits) for bits in tiny_states\n",
+        "]\n",
+        "tiny_direct_energies = [\n",
+        "    pathway_energy(tiny_coverage, tiny_A, bits; alpha = tiny_alpha)\n",
+        "    for bits in tiny_states\n",
+        "]\n",
+        "tiny_pair_expansion_energies = [\n",
+        "    2 * sum(\n",
+        "        tiny_A[i, j] * bits[i] * bits[j]\n",
+        "        for i in eachindex(bits), j in eachindex(bits) if i < j\n",
+        "    ) - tiny_alpha * sum(tiny_coverage .* bits)\n",
+        "    for bits in tiny_states\n",
+        "]\n",
+        "\n",
+        "@assert length(tiny_states) == 16\n",
+        "@assert all(isapprox.(tiny_jump_energies, tiny_direct_energies; atol = 1e-9, rtol = 0))\n",
+        "@assert tiny_pair_expansion_energies == tiny_direct_energies\n",
+        "\n",
+        "println(\"All 16 assignments match the analytic matrix and explicit pairwise energies.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "exact-check",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Enumerated optimum energy: -3.75\n",
+            "ExactSampler returns the same 2 global minima: [[1, 0, 0, 1], [1, 0, 1, 0]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "tiny_enumerated_best_energy = minimum(tiny_direct_energies)\n",
+        "tiny_enumerated_optima = tiny_states[findall(==(tiny_enumerated_best_energy), tiny_direct_energies)]\n",
+        "\n",
+        "tiny_exact_best_energy, tiny_exact_optima = exact_sampler_optima!(tiny_model, tiny_x)\n",
+        "@assert tiny_enumerated_best_energy == -3.75\n",
+        "@assert Set(Tuple.(tiny_enumerated_optima)) == Set(((1, 0, 1, 0), (1, 0, 0, 1)))\n",
+        "@assert isapprox(tiny_exact_best_energy, tiny_enumerated_best_energy; atol = 1e-9, rtol = 0)\n",
+        "@assert same_states(tiny_exact_optima, tiny_enumerated_optima)\n",
+        "\n",
+        "println(\"Enumerated optimum energy: $tiny_enumerated_best_energy\")\n",
+        "println(\"ExactSampler returns the same $(length(tiny_exact_optima)) global minima: $tiny_exact_optima\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "decode-heading",
+      "metadata": {},
+      "source": [
+        "## Decode pathway metrics safely\n",
+        "\n",
+        "The coverage reward is the sum of per-gene patient counts and can count a patient more than once. Distinct-patient coverage is the union of affected patients. The tiny incidence matrix lets us compute that union exactly. Pairwise co-mutation is reported once per undirected gene pair, while the QUBO uses twice that value.\n",
+        "\n",
+        "A zero- or one-gene pathway has no gene pairs, so the pair fraction is reported as missing instead of dividing by zero.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "tiny-decode",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Selected genes: G-A, G-C\n",
+            "Coverage sum: 5; distinct-patient coverage: 5\n",
+            "Pairwise co-mutation: 0; raw energy: -3.75\n"
+          ]
+        }
+      ],
+      "source": [
+        "tiny_representative = first(tiny_enumerated_optima)\n",
+        "tiny_metrics = decoded_pathway_metrics(\n",
+        "    tiny_genes,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    tiny_representative;\n",
+        "    incidence = tiny_B,\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "@assert validate_decoded_metrics(\n",
+        "    tiny_metrics,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    tiny_representative;\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "@assert tiny_metrics.selected_genes == [\"G-A\", \"G-C\"]\n",
+        "@assert tiny_metrics.pathway_size == 2\n",
+        "@assert tiny_metrics.coverage_sum == 5\n",
+        "@assert tiny_metrics.exact_unique_coverage == 5\n",
+        "@assert tiny_metrics.pairwise_comutation == 0\n",
+        "@assert tiny_metrics.zero_comutation_pair_fraction == 1.0\n",
+        "\n",
+        "println(\"Selected genes: $(join(tiny_metrics.selected_genes, \", \"))\")\n",
+        "println(\"Coverage sum: $(tiny_metrics.coverage_sum); distinct-patient coverage: $(tiny_metrics.exact_unique_coverage)\")\n",
+        "println(\"Pairwise co-mutation: $(tiny_metrics.pairwise_comutation); raw energy: $(pathway_energy(tiny_coverage, tiny_A, tiny_representative; alpha = tiny_alpha))\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "empty-decode",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Empty pathway decoded safely: size=0, coverage=0, co-mutation=0, energy=0.\n"
+          ]
+        }
+      ],
+      "source": [
+        "tiny_empty = zeros(Int, length(tiny_genes))\n",
+        "tiny_empty_metrics = decoded_pathway_metrics(\n",
+        "    tiny_genes,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    tiny_empty;\n",
+        "    incidence = tiny_B,\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "@assert validate_decoded_metrics(\n",
+        "    tiny_empty_metrics,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    tiny_empty;\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "@assert tiny_empty_metrics.pathway_size == 0\n",
+        "@assert tiny_empty_metrics.coverage_sum == 0\n",
+        "@assert tiny_empty_metrics.exact_unique_coverage == 0\n",
+        "@assert tiny_empty_metrics.unique_coverage_bounds == (lower = 0, upper = 0)\n",
+        "@assert ismissing(tiny_empty_metrics.zero_comutation_pair_fraction)\n",
+        "@assert pathway_energy(tiny_coverage, tiny_A, tiny_empty; alpha = tiny_alpha) == 0\n",
+        "\n",
+        "println(\"Empty pathway decoded safely: size=0, coverage=0, co-mutation=0, energy=0.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "aggregate-heading",
+      "metadata": {},
+      "source": [
+        "## Provenance-checked TCGA AML aggregate\n",
+        "\n",
+        "The full educational example loads three committed CSV files and their JSON provenance record. The data refresh was performed separately by the reviewed workflow in issue #91; this notebook never contacts cBioPortal. The files retain only gene labels, coverage counts, pairwise co-mutation counts, and aggregate provenance. They contain no patient or sample identifiers.\n",
+        "\n",
+        "The loader cross-checks gene ordering across all files, integer bounds, symmetry, zero diagonal, and the selected-gene and patient counts recorded in provenance.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "artifact-loader",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "load_tcga_aml_aggregate"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "function split_csv_lines(path)\n",
+        "    return [split(line, ',') for line in readlines(path)]\n",
+        "end\n",
+        "\n",
+        "\"\"\"\n",
+        "    load_tcga_aml_aggregate(repo_root)\n",
+        "\n",
+        "Load and cross-check the committed cancer-genomics aggregate without network\n",
+        "access. The repository artifact uses a simple comma-delimited schema with no\n",
+        "quoted fields.\n",
+        "\"\"\"\n",
+        "function load_tcga_aml_aggregate(repo_root)\n",
+        "    data_dir = joinpath(repo_root, \"notebooks_data\")\n",
+        "    gene_rows = split_csv_lines(joinpath(data_dir, \"9-CancerGenomics_genes.csv\"))\n",
+        "    coverage_rows = split_csv_lines(joinpath(data_dir, \"9-CancerGenomics_coverage.csv\"))\n",
+        "    matrix_rows = split_csv_lines(joinpath(data_dir, \"9-CancerGenomics_comutation.csv\"))\n",
+        "    provenance = JSON.parsefile(joinpath(data_dir, \"9-CancerGenomics_provenance.json\"))\n",
+        "\n",
+        "    @assert gene_rows[1] == [\"rank\", \"gene\", \"mutation_record_count\", \"patient_coverage\"]\n",
+        "    @assert coverage_rows[1] == [\"gene\", \"patient_count\"]\n",
+        "\n",
+        "    genes = String[row[2] for row in gene_rows[2:end]]\n",
+        "    ranks = parse.(Int, [row[1] for row in gene_rows[2:end]])\n",
+        "    gene_file_coverage = parse.(Int, [row[4] for row in gene_rows[2:end]])\n",
+        "    coverage_genes = String[row[1] for row in coverage_rows[2:end]]\n",
+        "    coverage = parse.(Int, [row[2] for row in coverage_rows[2:end]])\n",
+        "    matrix_genes = String.(matrix_rows[1][2:end])\n",
+        "\n",
+        "    @assert ranks == collect(eachindex(genes))\n",
+        "    @assert length(genes) == length(unique(genes))\n",
+        "    @assert genes == coverage_genes == matrix_genes\n",
+        "    @assert coverage == gene_file_coverage\n",
+        "    @assert all(>=(0), coverage)\n",
+        "\n",
+        "    A = zeros(Int, length(genes), length(genes))\n",
+        "    for (i, row) in enumerate(matrix_rows[2:end])\n",
+        "        @assert row[1] == genes[i]\n",
+        "        @assert length(row) == length(genes) + 1\n",
+        "        A[i, :] = parse.(Int, row[2:end])\n",
+        "    end\n",
+        "\n",
+        "    @assert A == A'\n",
+        "    @assert iszero(diag(A))\n",
+        "    @assert all(A .>= 0)\n",
+        "    @assert all(A[i, j] <= min(coverage[i], coverage[j]) for i in eachindex(genes), j in eachindex(genes))\n",
+        "\n",
+        "    aggregate = provenance[\"aggregate\"]\n",
+        "    patient_count = Int(aggregate[\"patient_count\"])\n",
+        "    @assert length(genes) == Int(aggregate[\"selected_gene_count\"])\n",
+        "    @assert patient_count > 0\n",
+        "\n",
+        "    return (\n",
+        "        genes = genes,\n",
+        "        coverage = coverage,\n",
+        "        D = Diagonal(coverage),\n",
+        "        A = A,\n",
+        "        patient_count = patient_count,\n",
+        "        provenance = provenance,\n",
+        "    )\n",
+        "end\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "id": "load-aggregate",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Loaded 33 genes for 196 aggregate patients.\n",
+            "Source retrieval recorded at 2026-07-20T13:05:32Z; default execution made no network request.\n"
+          ]
+        }
+      ],
+      "source": [
+        "aml = load_tcga_aml_aggregate(QUBONOTEBOOKS_REPO_DIR)\n",
+        "\n",
+        "@assert length(aml.genes) == 33\n",
+        "@assert aml.patient_count == 196\n",
+        "@assert aml.A == aml.A'\n",
+        "@assert iszero(diag(aml.A))\n",
+        "@assert all(\n",
+        "    aml.A[i, j] <= min(aml.coverage[i], aml.coverage[j])\n",
+        "    for i in eachindex(aml.genes), j in eachindex(aml.genes)\n",
+        ")\n",
+        "\n",
+        "println(\"Loaded $(length(aml.genes)) genes for $(aml.patient_count) aggregate patients.\")\n",
+        "println(\"Source retrieval recorded at $(aml.provenance[\"retrieved_at\"]); default execution made no network request.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "aggregate-limits",
+      "metadata": {},
+      "source": [
+        "### What the aggregate can and cannot decode\n",
+        "\n",
+        "For a selected set $S$, the files determine the coverage reward $\\sum_{g\\in S}D_g$, every pairwise co-mutation $A_{ij}$, and the QUBO energy exactly. They do not determine the exact union of affected patients for arbitrary $|S|>2$: triple and higher intersections were intentionally not committed.\n",
+        "\n",
+        "We therefore report a rigorous interval. The largest selected-gene coverage and the second-order Bonferroni expression $\\sum D_g-\\sum_{i<j}A_{ij}$ give lower bounds; the patient count and $\\sum D_g$ give upper bounds. This preserves the privacy/minimal-data design of issue #91 and avoids fabricating a distinct-patient count.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "sampler-helper",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "sample_aggregate (generic function with 1 method)"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "function sample_aggregate(\n",
+        "    gene_names,\n",
+        "    coverage,\n",
+        "    A;\n",
+        "    alpha,\n",
+        "    patient_count,\n",
+        "    seed,\n",
+        "    num_reads,\n",
+        "    num_sweeps,\n",
+        ")\n",
+        "    model, variables = build_pathway_model(coverage, A; alpha = alpha)\n",
+        "    set_optimizer(model, DWave.Neal.Optimizer)\n",
+        "    set_optimizer_attribute(model, \"num_reads\", num_reads)\n",
+        "    set_optimizer_attribute(model, \"num_sweeps\", num_sweeps)\n",
+        "    set_optimizer_attribute(model, \"seed\", seed)\n",
+        "    optimize!(model)\n",
+        "    @assert termination_status(model) == JuMP.MOI.LOCALLY_SOLVED\n",
+        "\n",
+        "    samples = [\n",
+        "        begin\n",
+        "            bits = round.(Int, value.(variables; result = result))\n",
+        "            reported_energy = objective_value(model; result = result)\n",
+        "            recomputed_energy = pathway_energy(coverage, A, bits; alpha = alpha)\n",
+        "            metrics = decoded_pathway_metrics(\n",
+        "                gene_names,\n",
+        "                coverage,\n",
+        "                A,\n",
+        "                bits;\n",
+        "                patient_count = patient_count,\n",
+        "            )\n",
+        "\n",
+        "            @assert isapprox(reported_energy, recomputed_energy; atol = 1e-8, rtol = 0)\n",
+        "            @assert validate_decoded_metrics(\n",
+        "                metrics,\n",
+        "                coverage,\n",
+        "                A,\n",
+        "                bits;\n",
+        "                patient_count = patient_count,\n",
+        "            )\n",
+        "\n",
+        "            (\n",
+        "                bits = bits,\n",
+        "                reported_energy = reported_energy,\n",
+        "                recomputed_energy = recomputed_energy,\n",
+        "                metrics = metrics,\n",
+        "            )\n",
+        "        end\n",
+        "        for result in 1:result_count(model)\n",
+        "    ]\n",
+        "    sort!(samples; by = sample -> (sample.reported_energy, Tuple(sample.bits)))\n",
+        "\n",
+        "    return samples\n",
+        "end\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "id": "aggregate-samples",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Seeded local Neal sampler: seed=94094, reads=500, sweeps=2000\n",
+            "alpha  states checked  size  coverage sum  distinct-patient bounds  pair co-mutation  raw energy\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "0.25      13      13     4            91        91–91                  0      -22.75\n",
+            "      selected genes: NPM1, RUNX1, TP53, FCGBP\n",
+            "0.45       8       8     6           109       106–109                 3      -43.05\n",
+            "      selected genes: FLT3, RUNX1, TP53, KIT, KRAS, FCGBP\n",
+            "1.00      23      23    11           152       133–152                19     -114.00\n",
+            "      selected genes: FLT3, RUNX1, TP53, CEBPA, IDH1, KIT, KRAS, RAD21, CROCC, CSMD1, FCGBP\n"
+          ]
+        }
+      ],
+      "source": [
+        "alpha_cases = [0.25, 0.45, 1.0]\n",
+        "sampler_seed = 94094\n",
+        "sampler_reads = 500\n",
+        "sampler_sweeps = 2_000\n",
+        "\n",
+        "aggregate_results = [\n",
+        "    begin\n",
+        "        samples = sample_aggregate(\n",
+        "            aml.genes,\n",
+        "            aml.coverage,\n",
+        "            aml.A;\n",
+        "            alpha = alpha,\n",
+        "            patient_count = aml.patient_count,\n",
+        "            seed = sampler_seed,\n",
+        "            num_reads = sampler_reads,\n",
+        "            num_sweeps = sampler_sweeps,\n",
+        "        )\n",
+        "        best = first(samples)\n",
+        "        (\n",
+        "            alpha = alpha,\n",
+        "            returned_states = length(samples),\n",
+        "            validated_states = length(samples),\n",
+        "            bits = best.bits,\n",
+        "            genes = best.metrics.selected_genes,\n",
+        "            pathway_size = best.metrics.pathway_size,\n",
+        "            coverage_sum = best.metrics.coverage_sum,\n",
+        "            unique_coverage_bounds = best.metrics.unique_coverage_bounds,\n",
+        "            pairwise_comutation = best.metrics.pairwise_comutation,\n",
+        "            raw_energy = best.recomputed_energy,\n",
+        "        )\n",
+        "    end\n",
+        "    for alpha in alpha_cases\n",
+        "]\n",
+        "\n",
+        "@assert all(result.returned_states == result.validated_states for result in aggregate_results)\n",
+        "@assert length(unique(result.pathway_size for result in aggregate_results)) > 1\n",
+        "@assert length(unique(Tuple(result.bits) for result in aggregate_results)) > 1\n",
+        "\n",
+        "println(\"Seeded local Neal sampler: seed=$sampler_seed, reads=$sampler_reads, sweeps=$sampler_sweeps\")\n",
+        "println(\"alpha  states checked  size  coverage sum  distinct-patient bounds  pair co-mutation  raw energy\")\n",
+        "for result in aggregate_results\n",
+        "    bounds = result.unique_coverage_bounds\n",
+        "    @printf(\n",
+        "        \"%4.2f %7d %7d %5d %13d %9d–%-3d %17d %11.2f\\n\",\n",
+        "        result.alpha,\n",
+        "        result.returned_states,\n",
+        "        result.validated_states,\n",
+        "        result.pathway_size,\n",
+        "        result.coverage_sum,\n",
+        "        bounds.lower,\n",
+        "        bounds.upper,\n",
+        "        result.pairwise_comutation,\n",
+        "        result.raw_energy,\n",
+        "    )\n",
+        "    println(\"      selected genes: $(join(result.genes, \", \"))\")\n",
+        "end\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "sensitivity-interpretation",
+      "metadata": {},
+      "source": [
+        "The sampled pathway size and composition change across the three $\\alpha$ values. These are reproducible outputs from a locked, seeded local sampler, not proofs of global optimality. The validity claim is narrower and checked for every returned state: its bit vector, decoded metrics, and independently recomputed raw energy agree.\n",
+        "\n",
+        "Increasing $\\alpha$ makes coverage more valuable relative to the pairwise co-mutation penalty, so larger selected sets become more attractive. No clinical interpretation is made from any selected name.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "practice",
+      "metadata": {},
+      "source": [
+        "## Practice checkpoints\n",
+        "\n",
+        "1. For the tiny state selecting G-A and G-B, compute the undirected co-mutation count and predict the contribution of $x^{\\mathsf{T}}Ax$. Confirm the factor of two.\n",
+        "2. Enumerate the tiny fixture at $\\alpha=0.5$ and $\\alpha=1.5$. Compare the optimal pathway sizes without relying on stochastic output.\n",
+        "3. Select G-A, G-B, and G-C. Derive the aggregate-style distinct-patient bounds, then use the incidence matrix to locate the exact union inside them.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "id": "exercise-double-count",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# EXERCISE: select G-A and G-B, then compare one undirected overlap\n",
+        "# with the symmetric matrix contribution x' * A * x.\n",
+        "nothing\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "id": "solution-double-count",
+      "metadata": {
+        "tags": [
+          "hide-cell",
+          "solution"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "One undirected co-mutation contributes 2 to the symmetric matrix energy.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# SOLUTION (hidden in workshop version):\n",
+        "overlap_bits = [1, 1, 0, 0]\n",
+        "one_counted_overlap = tiny_A[1, 2]\n",
+        "matrix_overlap = dot(overlap_bits, tiny_A * overlap_bits)\n",
+        "@assert one_counted_overlap == 1\n",
+        "@assert matrix_overlap == 2 * one_counted_overlap == 2\n",
+        "println(\"One undirected co-mutation contributes $matrix_overlap to the symmetric matrix energy.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "exercise-alpha",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# EXERCISE: enumerate the tiny fixture at alpha=0.5 and alpha=1.5.\n",
+        "# Compare complete sets of minimizers and their pathway sizes.\n",
+        "nothing\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "id": "solution-alpha",
+      "metadata": {
+        "tags": [
+          "hide-cell",
+          "solution"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Tiny optimum sizes: alpha=0.5 → [2], alpha=1.5 → [4]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# SOLUTION (hidden in workshop version):\n",
+        "tiny_sensitivity = [\n",
+        "    begin\n",
+        "        energies = [\n",
+        "            pathway_energy(tiny_coverage, tiny_A, bits; alpha = alpha)\n",
+        "            for bits in tiny_states\n",
+        "        ]\n",
+        "        best_energy = minimum(energies)\n",
+        "        optima = tiny_states[findall(==(best_energy), energies)]\n",
+        "        (\n",
+        "            alpha = alpha,\n",
+        "            energy = best_energy,\n",
+        "            sizes = sort(unique(sum(bits) for bits in optima)),\n",
+        "            optima = optima,\n",
+        "        )\n",
+        "    end\n",
+        "    for alpha in (0.5, 1.5)\n",
+        "]\n",
+        "@assert tiny_sensitivity[1].sizes == [2]\n",
+        "@assert tiny_sensitivity[2].sizes == [4]\n",
+        "println(\"Tiny optimum sizes: alpha=0.5 → $(tiny_sensitivity[1].sizes), alpha=1.5 → $(tiny_sensitivity[2].sizes)\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "id": "exercise-bounds",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# EXERCISE: select G-A, G-B, and G-C.\n",
+        "# Compute the union bounds from D and A before checking the exact incidence rows.\n",
+        "nothing\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "id": "solution-bounds",
+      "metadata": {
+        "tags": [
+          "hide-cell",
+          "solution"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Aggregate-style bounds: 6–7 patients; incidence-derived exact union: 6 patients.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# SOLUTION (hidden in workshop version):\n",
+        "bound_bits = [1, 1, 1, 0]\n",
+        "bounded_metrics = decoded_pathway_metrics(\n",
+        "    tiny_genes,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    bound_bits;\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "exact_metrics = decoded_pathway_metrics(\n",
+        "    tiny_genes,\n",
+        "    tiny_coverage,\n",
+        "    tiny_A,\n",
+        "    bound_bits;\n",
+        "    incidence = tiny_B,\n",
+        "    patient_count = length(tiny_patients),\n",
+        ")\n",
+        "@assert bounded_metrics.unique_coverage_bounds == (lower = 6, upper = 7)\n",
+        "@assert exact_metrics.exact_unique_coverage == 6\n",
+        "@assert bounded_metrics.unique_coverage_bounds.lower <=\n",
+        "    exact_metrics.exact_unique_coverage <=\n",
+        "    bounded_metrics.unique_coverage_bounds.upper\n",
+        "println(\"Aggregate-style bounds: 6–7 patients; incidence-derived exact union: 6 patients.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "summary",
+      "metadata": {},
+      "source": [
+        "## Summary\n",
+        "\n",
+        "**Learning objectives met:**\n",
+        "\n",
+        "- A patient-by-gene incidence matrix yields coverage $D$ and a zero-diagonal symmetric co-mutation matrix $A$ by visiting every $i<j$ pair.\n",
+        "- The QUBO $x^{\\mathsf{T}}(A-\\alpha D)x$ counts each undirected co-mutation twice, consistently in code and mathematics.\n",
+        "- All 16 tiny states agree across the analytic matrix formula, explicit pair expansion, JuMP objective, and ExactSampler optimum set.\n",
+        "- Empty-pathway metrics are safe, and exact distinct-patient coverage is computed only when incidence rows are available.\n",
+        "- The committed 33-gene aggregate loads without a service call; every state returned by the seeded local sampler passes independent energy and metric checks.\n",
+        "- Aggregate distinct-patient coverage is reported as a rigorous interval because higher-order patient intersections are not present.\n",
+        "\n",
+        "**Next steps:** Notebook 11 will compare solver interfaces and optional D-Wave hardware. This modeling notebook intentionally stops at a local, credential-free sampler and makes no performance claim.\n",
+        "\n",
+        "**Further reading:**\n",
+        "\n",
+        "- The Five Starter Problems tutorial gives the displayed QUBO formulation and its coverage/exclusivity motivation.\n",
+        "- Alghassi et al. develop quantum and quantum-inspired formulations for altered-pathway discovery.\n",
+        "- Ley et al. describe the underlying TCGA AML study; the committed provenance explains the exact cBioPortal aggregate used here.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "references",
+      "metadata": {},
+      "source": [
+        "## References\n",
+        "\n",
+        "1. A. R. Mazumder and S. Tayur, *Five Starter Problems: Solving Quadratic Unconstrained Binary Optimization Models on Quantum Computers*, TutORials in Operations Research (2025), pp. 145–183, https://doi.org/10.1287/educ.2025.0288.\n",
+        "2. H. Alghassi, R. Dridi, A. G. Robertson, and S. Tayur, *Quantum and Quantum-inspired Methods for de novo Discovery of Altered Cancer Pathways*, bioRxiv 845719 (2019), https://doi.org/10.1101/845719.\n",
+        "3. T. J. Ley et al., *Genomic and Epigenomic Landscapes of Adult De Novo Acute Myeloid Leukemia*, New England Journal of Medicine 368 (2013), pp. 2059–2074, https://doi.org/10.1056/NEJMoa1301689.\n",
+        "4. E. Cerami et al., *The cBio Cancer Genomics Portal: An Open Platform for Exploring Multidimensional Cancer Genomics Data*, Cancer Discovery 2 (2012), pp. 401–404, https://doi.org/10.1158/2159-8290.CD-12-0095; current portal: https://www.cbioportal.org/.\n",
+        "5. Companion materials: https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers.\n",
+        "6. D-Wave Neal simulated annealing documentation: https://docs.ocean.dwavesys.com/projects/neal/en/latest/.\n",
+        "\n",
+        "The committed artifact's exact query, retrieval time, aggregation rules, license, and checksums are recorded in notebooks_data/9-CancerGenomics_provenance.json. This notebook contains original Julia code and prose. The unlicensed companion repository is cited as context; no cells, prose, outputs, figures, or assets were copied.\n",
+        "\n",
+        "This educational reproduction is not a clinically validated pathway analysis, biomarker study, diagnostic tool, or medical guidance.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Julia",
+      "language": "julia",
+      "name": "julia"
+    },
+    "language_info": {
+      "file_extension": ".jl",
+      "mimetype": "application/julia",
+      "name": "julia",
+      "version": "1.10.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ notebook_links = [
     "notebooks_py/6-QCi_python.ipynb",
     "notebooks_jl/7-CanonicalProblems.ipynb",
     "notebooks_jl/8-OrderPartitioning.ipynb",
+    "notebooks_jl/9-CancerGenomics.ipynb",
 ]
 files_with_repository_links = [
     "README.md",

--- a/tests/test_cancer_genomics_notebook.py
+++ b/tests/test_cancer_genomics_notebook.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import csv
+import itertools
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK_PATH = REPO_ROOT / "notebooks_jl" / "9-CancerGenomics.ipynb"
+DATA_DIR = REPO_ROOT / "notebooks_data"
+
+
+def notebook() -> dict:
+    return json.loads(NOTEBOOK_PATH.read_text())
+
+
+def notebook_source() -> str:
+    return "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook()["cells"]
+    )
+
+
+def notebook_cell(data: dict, cell_id: str) -> dict:
+    matches = [cell for cell in data["cells"] if cell.get("id") == cell_id]
+    if len(matches) != 1:
+        raise AssertionError(f"Expected one cell with id {cell_id!r}, found {len(matches)}")
+    return matches[0]
+
+
+def cell_output_text(cell: dict) -> str:
+    output_parts = []
+    for output in cell.get("outputs", []):
+        value = output.get("text", output.get("data", {}).get("text/plain", ""))
+        output_parts.append("".join(value) if isinstance(value, list) else value)
+    return "\n".join(output_parts)
+
+
+def binary_states(size: int) -> list[tuple[int, ...]]:
+    return list(itertools.product((0, 1), repeat=size))
+
+
+TINY_B = (
+    (1, 1, 0, 0),
+    (1, 0, 0, 0),
+    (1, 0, 0, 0),
+    (0, 1, 0, 0),
+    (0, 0, 1, 1),
+    (0, 0, 1, 0),
+    (0, 0, 0, 1),
+)
+
+
+def coverage_and_comutation(
+    incidence: tuple[tuple[int, ...], ...],
+) -> tuple[tuple[int, ...], tuple[tuple[int, ...], ...]]:
+    gene_count = len(incidence[0])
+    coverage = tuple(sum(row[j] for row in incidence) for j in range(gene_count))
+    matrix = [[0] * gene_count for _ in range(gene_count)]
+
+    for i in range(gene_count - 1):
+        for j in range(i + 1, gene_count):
+            overlap = sum(row[i] * row[j] for row in incidence)
+            matrix[i][j] = overlap
+            matrix[j][i] = overlap
+
+    return coverage, tuple(tuple(row) for row in matrix)
+
+
+TINY_COVERAGE, TINY_A = coverage_and_comutation(TINY_B)
+
+
+def pathway_energy(bits: tuple[int, ...], *, alpha: float) -> float:
+    pairwise = sum(
+        TINY_A[i][j] * bits[i] * bits[j]
+        for i in range(len(bits))
+        for j in range(i + 1, len(bits))
+    )
+    coverage_reward = sum(value * bit for value, bit in zip(TINY_COVERAGE, bits))
+    return 2 * pairwise - alpha * coverage_reward
+
+
+def selected_metrics(
+    coverage: tuple[int, ...],
+    matrix: tuple[tuple[int, ...], ...],
+    bits: tuple[int, ...],
+    *,
+    patient_count: int,
+) -> dict:
+    selected = tuple(i for i, bit in enumerate(bits) if bit)
+    coverage_sum = sum(coverage[i] for i in selected)
+    pairwise = sum(matrix[i][j] for i in selected for j in selected if i < j)
+    if selected:
+        lower = max(max(coverage[i] for i in selected), coverage_sum - pairwise)
+        upper = min(patient_count, coverage_sum)
+    else:
+        lower = upper = 0
+    pair_count = len(selected) * (len(selected) - 1) // 2
+    zero_pairs = sum(
+        matrix[i][j] == 0 for i in selected for j in selected if i < j
+    )
+
+    return {
+        "selected": selected,
+        "coverage_sum": coverage_sum,
+        "pairwise": pairwise,
+        "double_counted": 2 * pairwise,
+        "bounds": (lower, upper),
+        "zero_pair_fraction": None if pair_count == 0 else zero_pairs / pair_count,
+    }
+
+
+class CancerGenomicsNotebookSourceTests(unittest.TestCase):
+    def test_notebook_has_required_tutorial_structure_and_references(self) -> None:
+        source = notebook_source()
+        required_markers = (
+            "## Setup",
+            "## Learning objectives",
+            "## Prerequisites",
+            "## From incidence data to coverage and co-mutation",
+            "## Build and interpret the QUBO",
+            "## Exhaustive validation on the tiny fixture",
+            "## Decode pathway metrics safely",
+            "## Provenance-checked TCGA AML aggregate",
+            "## Practice checkpoints",
+            "## Summary",
+            "## References",
+            "https://doi.org/10.1287/educ.2025.0288",
+            "https://doi.org/10.1101/845719",
+            "https://doi.org/10.1056/NEJMoa1301689",
+            "https://www.cbioportal.org/",
+            "https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers",
+            "original Julia code and prose",
+            "not a clinically validated pathway",
+            "not medical guidance",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, source)
+
+    def test_pair_construction_and_double_counting_are_explicit(self) -> None:
+        data = notebook()
+        construction = "".join(notebook_cell(data, "matrix-helpers")["source"])
+        formula = "".join(notebook_cell(data, "metric-helpers")["source"])
+        all_state_check = "".join(notebook_cell(data, "all-state-check")["source"])
+
+        self.assertIn("for i in 1:(n_genes - 1)", construction)
+        self.assertIn("for j in (i + 1):n_genes", construction)
+        self.assertIn("A[i, j] = overlap", construction)
+        self.assertIn("A[j, i] = overlap", construction)
+        self.assertNotIn("if i != j", construction)
+        self.assertIn("dot(bits, A * bits)", formula)
+        self.assertIn(
+            "double_counted_comutation == 2 * pairwise_comutation",
+            formula,
+        )
+        self.assertIn("tiny_pair_expansion_energies", all_state_check)
+        self.assertIn("2 * sum(", all_state_check)
+
+    def test_decoding_handles_empty_and_aggregate_only_paths(self) -> None:
+        data = notebook()
+        helpers = "".join(notebook_cell(data, "metric-helpers")["source"])
+        empty_check = "".join(notebook_cell(data, "empty-decode")["source"])
+        aggregate_limits = "".join(notebook_cell(data, "aggregate-limits")["source"])
+
+        self.assertIn("pair_count == 0 ? missing", helpers)
+        self.assertIn("isempty(selected) && return (lower = 0, upper = 0)", helpers)
+        self.assertIn("exact_unique_coverage = missing", helpers)
+        self.assertIn("Bonferroni", helpers)
+        self.assertIn("ismissing(tiny_empty_metrics.zero_comutation_pair_fraction)", empty_check)
+        self.assertIn("triple and higher intersections", aggregate_limits)
+        self.assertIn("avoids fabricating a distinct-patient count", aggregate_limits)
+
+    def test_full_run_is_seeded_local_and_validates_every_returned_state(self) -> None:
+        data = notebook()
+        sampler = "".join(notebook_cell(data, "sampler-helper")["source"])
+        run = "".join(notebook_cell(data, "aggregate-samples")["source"])
+        source = notebook_source()
+
+        for marker in (
+            "set_optimizer(model, DWave.Neal.Optimizer)",
+            'set_optimizer_attribute(model, "num_reads", num_reads)',
+            'set_optimizer_attribute(model, "num_sweeps", num_sweeps)',
+            'set_optimizer_attribute(model, "seed", seed)',
+            "for result in 1:result_count(model)",
+            "reported_energy",
+            "recomputed_energy",
+            "validate_decoded_metrics",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, sampler)
+
+        self.assertIn("returned_states == result.validated_states", run)
+        self.assertIn("length(unique(result.pathway_size", run)
+        self.assertIn("length(unique(Tuple(result.bits)", run)
+        self.assertNotIn("@assert result.genes", run)
+        self.assertNotIn("@assert result.bits", run)
+        self.assertIn("not proofs of global optimality", source)
+
+        for forbidden in (
+            "DWave.Optimizer",
+            "DWAVE_API_TOKEN",
+            "save_account",
+            "Downloads.download",
+            "HTTP.get",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, source)
+
+    def test_notebook_commits_reproducible_outputs(self) -> None:
+        data = notebook()
+        code_cells = [cell for cell in data["cells"] if cell["cell_type"] == "code"]
+
+        self.assertTrue(code_cells)
+        self.assertEqual(
+            list(range(1, len(code_cells) + 1)),
+            [cell.get("execution_count") for cell in code_cells],
+        )
+        self.assertEqual([], notebook_cell(data, "bootstrap").get("outputs", []))
+        self.assertEqual([], notebook_cell(data, "activate").get("outputs", []))
+
+        expected_output_markers = {
+            "tiny-matrices": "D diagonal = [3, 2, 2, 2]",
+            "all-state-check": "All 16 assignments match",
+            "exact-check": "Enumerated optimum energy: -3.75",
+            "tiny-decode": "distinct-patient coverage: 5",
+            "empty-decode": "Empty pathway decoded safely",
+            "load-aggregate": "Loaded 33 genes for 196 aggregate patients",
+            "aggregate-samples": "Seeded local Neal sampler",
+            "solution-double-count": "symmetric matrix energy",
+            "solution-alpha": "Tiny optimum sizes",
+            "solution-bounds": "incidence-derived exact union",
+        }
+        for cell_id, marker in expected_output_markers.items():
+            with self.subTest(cell_id=cell_id):
+                self.assertIn(marker, cell_output_text(notebook_cell(data, cell_id)))
+
+        self.assertFalse(
+            any(
+                output.get("output_type") == "error"
+                for cell in code_cells
+                for output in cell.get("outputs", [])
+            )
+        )
+        serialized_outputs = json.dumps(
+            [cell.get("outputs", []) for cell in code_cells], ensure_ascii=False
+        )
+        for marker in ("/home/", "/Users/", "C:\\Users", "AppData", "Bearer "):
+            with self.subTest(forbidden_output_marker=marker):
+                self.assertNotIn(marker, serialized_outputs)
+
+    def test_notebook_and_target_are_linked(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text()
+        makefile = (REPO_ROOT / "Makefile").read_text()
+        julia_tests = (REPO_ROOT / "test" / "runtests.jl").read_text()
+        verifier_tests = (REPO_ROOT / "tests" / "test_verify_notebooks.py").read_text()
+
+        self.assertIn("notebooks_jl/9-CancerGenomics.ipynb", readme)
+        self.assertIn("make verify-cancer-genomics-julia", readme)
+        self.assertIn("verify-cancer-genomics-julia:", makefile)
+        self.assertIn('NOTEBOOKS="$(CANCER_GENOMICS_JULIA_NOTEBOOK)"', makefile)
+        self.assertIn('"notebooks_jl/9-CancerGenomics.ipynb"', julia_tests)
+        self.assertIn("CANCER_GENOMICS_JULIA_NOTEBOOK_PATH", verifier_tests)
+
+
+class CancerGenomicsMathematicalInvariantTests(unittest.TestCase):
+    def test_fixture_derives_known_coverage_and_symmetric_matrix(self) -> None:
+        self.assertEqual((3, 2, 2, 2), TINY_COVERAGE)
+        self.assertEqual(
+            (
+                (0, 1, 0, 0),
+                (1, 0, 0, 0),
+                (0, 0, 0, 1),
+                (0, 0, 1, 0),
+            ),
+            TINY_A,
+        )
+        self.assertTrue(all(TINY_A[i][i] == 0 for i in range(4)))
+        self.assertTrue(
+            all(TINY_A[i][j] == TINY_A[j][i] for i in range(4) for j in range(4))
+        )
+        self.assertTrue(
+            all(
+                TINY_A[i][j] <= min(TINY_COVERAGE[i], TINY_COVERAGE[j])
+                for i in range(4)
+                for j in range(4)
+            )
+        )
+
+    def test_explicit_pair_energy_matches_matrix_convention_for_all_states(self) -> None:
+        for bits in binary_states(4):
+            matrix_energy = sum(
+                bits[i] * TINY_A[i][j] * bits[j]
+                for i in range(4)
+                for j in range(4)
+            ) - 0.75 * sum(
+                value * bit for value, bit in zip(TINY_COVERAGE, bits)
+            )
+            with self.subTest(bits=bits):
+                self.assertEqual(pathway_energy(bits, alpha=0.75), matrix_energy)
+
+        states = binary_states(4)
+        best = min(pathway_energy(bits, alpha=0.75) for bits in states)
+        optima = {bits for bits in states if pathway_energy(bits, alpha=0.75) == best}
+        self.assertEqual(-3.75, best)
+        self.assertEqual({(1, 0, 1, 0), (1, 0, 0, 1)}, optima)
+
+    def test_alpha_changes_complete_tiny_optimum_sizes(self) -> None:
+        states = binary_states(4)
+
+        def optimum_sizes(alpha: float) -> set[int]:
+            best = min(pathway_energy(bits, alpha=alpha) for bits in states)
+            return {
+                sum(bits)
+                for bits in states
+                if pathway_energy(bits, alpha=alpha) == best
+            }
+
+        self.assertEqual({2}, optimum_sizes(0.5))
+        self.assertEqual({4}, optimum_sizes(1.5))
+
+    def test_empty_metrics_are_safe_and_union_bounds_contain_exact_value(self) -> None:
+        empty = selected_metrics(TINY_COVERAGE, TINY_A, (0, 0, 0, 0), patient_count=7)
+        self.assertEqual((), empty["selected"])
+        self.assertEqual(0, empty["coverage_sum"])
+        self.assertEqual(0, empty["pairwise"])
+        self.assertEqual((0, 0), empty["bounds"])
+        self.assertIsNone(empty["zero_pair_fraction"])
+
+        selected = (1, 1, 1, 0)
+        metrics = selected_metrics(TINY_COVERAGE, TINY_A, selected, patient_count=7)
+        exact_union = sum(
+            any(row[j] and selected[j] for j in range(4)) for row in TINY_B
+        )
+        self.assertEqual((6, 7), metrics["bounds"])
+        self.assertEqual(6, exact_union)
+        self.assertLessEqual(metrics["bounds"][0], exact_union)
+        self.assertLessEqual(exact_union, metrics["bounds"][1])
+
+    def test_committed_artifact_matches_notebook_input_contract(self) -> None:
+        with (DATA_DIR / "9-CancerGenomics_coverage.csv").open(newline="") as handle:
+            coverage_rows = list(csv.DictReader(handle))
+        with (DATA_DIR / "9-CancerGenomics_comutation.csv").open(newline="") as handle:
+            matrix_rows = list(csv.reader(handle))
+        provenance = json.loads(
+            (DATA_DIR / "9-CancerGenomics_provenance.json").read_text()
+        )
+
+        genes = [row["gene"] for row in coverage_rows]
+        coverage = [int(row["patient_count"]) for row in coverage_rows]
+        matrix = [[int(value) for value in row[1:]] for row in matrix_rows[1:]]
+
+        self.assertEqual(33, len(genes))
+        self.assertEqual(33, provenance["aggregate"]["selected_gene_count"])
+        self.assertEqual(196, provenance["aggregate"]["patient_count"])
+        self.assertEqual(["gene", *genes], matrix_rows[0])
+        self.assertEqual(33, len(matrix))
+        for i in range(33):
+            self.assertEqual(0, matrix[i][i])
+            for j in range(33):
+                self.assertEqual(matrix[i][j], matrix[j][i])
+                self.assertLessEqual(matrix[i][j], min(coverage[i], coverage[j]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -32,6 +32,9 @@ CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH = (
 ORDER_PARTITIONING_JULIA_NOTEBOOK_PATH = (
     REPO_ROOT / "notebooks_jl" / "8-OrderPartitioning.ipynb"
 )
+CANCER_GENOMICS_JULIA_NOTEBOOK_PATH = (
+    REPO_ROOT / "notebooks_jl" / "9-CancerGenomics.ipynb"
+)
 BENCHMARKING_RESULTS_ARCHIVES = (
     REPO_ROOT / "notebooks_py" / "results.zip",
     REPO_ROOT / "notebooks_jl" / "results.zip",
@@ -44,6 +47,7 @@ JULIA_COLAB_NOTEBOOK_PATHS = (
     REPO_ROOT / "notebooks_jl" / "5-Benchmarking.ipynb",
     CANONICAL_PROBLEMS_JULIA_NOTEBOOK_PATH,
     ORDER_PARTITIONING_JULIA_NOTEBOOK_PATH,
+    CANCER_GENOMICS_JULIA_NOTEBOOK_PATH,
 )
 BOOTSTRAP_PATH = REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
 NOTEBOOK_DIRS = (


### PR DESCRIPTION
## Summary

- Add an original Julia cancer-genomics QUBO case study with explicit educational and non-clinical scope.
- Derive the mutation-frequency vector `D` and symmetric co-mutation matrix `A` from a tiny patient-by-gene example, then cross-check all 16 binary states and the exact minima.
- Load the reproducible, privacy-preserving TCGA AML aggregate artifacts added by #91 entirely offline, with provenance, schema, ordering, and bounds validation.
- Run seeded `DWave.Neal` sampling across three `alpha` values and independently validate every returned energy and decoded pathway.
- Report exact distinct-patient coverage for the tiny example and rigorous Bonferroni coverage bounds for the aggregate, whose intentionally minimal schema cannot recover arbitrary higher-order unions.
- Add a fresh-kernel verification target, focused regression tests, notebook inventory coverage, and README documentation.

## Correctness and data limitations

- The notebook states and tests the symmetric-matrix convention: off-diagonal overlap terms are counted twice in `x' * A * x`.
- The committed aggregate contains mutation counts and pairwise overlaps, not patient identifiers or higher-order intersections, so it cannot support exact union sizes for arbitrary multi-gene pathways. The notebook exposes this limitation and reports valid lower and upper bounds instead.
- The stochastic sampler results are treated as reproducible heuristic samples, not proof of global optimality or clinically validated pathways.
- The notebook makes no network or service calls and requires no credentials or patient-level data.
- The formulation and biological context cite the primary tutorial, Alghassi et al., the TCGA AML study, and the data provenance sources; the notebook text and implementation are original.

## Verification

- `make verify-cancer-genomics-julia` — passed twice with a fresh Julia 1.10 kernel (about 35 seconds per run)
- `make test-python PYTHON=.venv/bin/python` — 129 tests passed
- `.venv/bin/python -m unittest tests.test_cancer_genomics_notebook` — 11 focused tests passed
- `make test-julia` — 86 checks passed
- `make test` — passed
- `make check-notebook-output-hygiene` — passed
- `uv lock --check --cache-dir .uv-cache` — passed
- `git diff --check` — passed
- A second execution was semantically identical after excluding transient environment logs, timing metadata, and stream chunking.
- A mutation check that broke the symmetric assignment failed the expected notebook assertion, confirming the regression guard is non-vacuous.

## Branch hygiene

- Base: `main`
- Branch point: `c84f58d45817923ecf284c74a2b7cf5b81a6a5ac`
- Source branch: `codex/issue-94-cancer-genomics`
- Unstacked; #91 was completed by merged PR #98 and supplies the aggregate artifacts.
- No overlapping open pull request was present at push time.

## Coordination

- Closes #94 and advances the roadmap in #90.
- #96 remains responsible for the broader local/QPU annealing comparison.
- #97 remains responsible for the final cross-series integration.

Closes #94
