### PR TITLE
Fix Colab first-cell package loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,11 @@ not yet have a locked local make target because `eqc-models==0.19.0` requires
 `networkx<3`, which conflicts with the D-Wave Ocean stack.
 The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
 repository when needed, activate `notebooks_jl`, and resolve the checked-in
-manifest for the current hosted Julia runtime. The bootstrap warms only the
-imports used by the selected notebook.
+manifest for the current hosted Julia runtime. Package imports and their
+automatic precompilation run in each notebook's dedicated import cell instead
+of the setup cell. Set `QUBONOTEBOOKS_WARM_PACKAGES=1` or
+`QUBONOTEBOOKS_PRECOMPILE=1` before setup to opt into either extra bootstrap
+step.
 
 ```bash
 make verify-notebooks NOTEBOOKS="notebooks_py/2-QUBO_python.ipynb" UV_GROUP_FLAGS="--group docs --group qubo"

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -61,13 +61,10 @@ function env_bool(name::AbstractString)
     error("Expected `$name` to be one of 1/0/true/false/yes/no/on/off, got `$value`.")
 end
 
-default_bootstrap_warm_packages(; in_colab::Bool = detect_colab()) =
+default_bootstrap_warm_packages() =
     something(env_bool("QUBONOTEBOOKS_WARM_PACKAGES"), false)
 
-default_bootstrap_precompile(;
-    in_colab::Bool = detect_colab(),
-    warm_packages::Bool = default_bootstrap_warm_packages(in_colab = in_colab),
-) = something(env_bool(PRECOMPILE_ENV), false)
+default_bootstrap_precompile() = something(env_bool(PRECOMPILE_ENV), false)
 
 function notebook_key(target::AbstractString)
     return splitext(basename(target))[1]
@@ -389,7 +386,7 @@ function bootstrap_notebook(
     needs_python::Bool = notebook_requires_python(project_key),
     python_packages::Vector{String} = ["dwave-ocean-sdk"],
     warm_packages::Bool = default_bootstrap_warm_packages(),
-    precompile::Bool = default_bootstrap_precompile(in_colab = detect_colab(), warm_packages = warm_packages),
+    precompile::Bool = default_bootstrap_precompile(),
     suppress_warmup_logs::Bool = warm_packages,
     chdir_to_notebooks::Bool = true,
 )

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -9,6 +9,7 @@ const WORKSPACE = normpath(joinpath(@__DIR__, ".."))
 const NOTEBOOKS_DIRNAME = "notebooks_jl"
 const ALLOW_VERSION_MISMATCH_ENV = "QUBONOTEBOOKS_ALLOW_JULIA_VERSION_MISMATCH"
 const REPO_REF_ENV = "QUBONOTEBOOKS_REPO_REF"
+const PRECOMPILE_ENV = "QUBONOTEBOOKS_PRECOMPILE"
 const PYTHON_STACK_NOTEBOOKS = Set((
     "2-QUBO",
     "3-GAMA",
@@ -61,12 +62,12 @@ function env_bool(name::AbstractString)
 end
 
 default_bootstrap_warm_packages(; in_colab::Bool = detect_colab()) =
-    something(env_bool("QUBONOTEBOOKS_WARM_PACKAGES"), in_colab)
+    something(env_bool("QUBONOTEBOOKS_WARM_PACKAGES"), false)
 
 default_bootstrap_precompile(;
     in_colab::Bool = detect_colab(),
     warm_packages::Bool = default_bootstrap_warm_packages(in_colab = in_colab),
-) = in_colab && !warm_packages
+) = something(env_bool(PRECOMPILE_ENV), false)
 
 function notebook_key(target::AbstractString)
     return splitext(basename(target))[1]

--- a/test/issue_90_colab_first_cell.jl
+++ b/test/issue_90_colab_first_cell.jl
@@ -8,7 +8,6 @@ using Test
     ) do
         @test !QUBONotebooksBootstrap.default_bootstrap_warm_packages()
         @test !QUBONotebooksBootstrap.default_bootstrap_precompile()
-        @test !QUBONotebooksBootstrap.default_bootstrap_precompile(warm_packages = false)
     end
 
     withenv(

--- a/test/issue_90_colab_first_cell.jl
+++ b/test/issue_90_colab_first_cell.jl
@@ -1,0 +1,41 @@
+using Test
+
+@testset "Issue 90 Colab first-cell setup" begin
+    withenv(
+        "COLAB_RELEASE_TAG" => "issue-90",
+        "QUBONOTEBOOKS_WARM_PACKAGES" => nothing,
+        "QUBONOTEBOOKS_PRECOMPILE" => nothing,
+    ) do
+        @test !QUBONotebooksBootstrap.default_bootstrap_warm_packages()
+        @test !QUBONotebooksBootstrap.default_bootstrap_precompile()
+        @test !QUBONotebooksBootstrap.default_bootstrap_precompile(warm_packages = false)
+    end
+
+    withenv(
+        "COLAB_RELEASE_TAG" => "issue-90",
+        "QUBONOTEBOOKS_WARM_PACKAGES" => "true",
+        "QUBONOTEBOOKS_PRECOMPILE" => "true",
+    ) do
+        @test QUBONotebooksBootstrap.default_bootstrap_warm_packages()
+        @test QUBONotebooksBootstrap.default_bootstrap_precompile()
+    end
+
+    for project_key in (
+        "7-CanonicalProblems",
+        "8-OrderPartitioning",
+        "9-CancerGenomics",
+        "10-QAOA",
+        "11-Annealing",
+    )
+        notebook = read(
+            joinpath(repo_root, "notebooks_jl", "$project_key.ipynb"),
+            String,
+        )
+
+        @test occursin(
+            "QUBONotebooksBootstrap.bootstrap_notebook, \\\"$project_key\\\"",
+            notebook,
+        )
+        @test occursin("\"id\": \"imports\"", notebook)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ import TOML
 
 repo_root = dirname(@__DIR__)
 include(joinpath(repo_root, "scripts", "notebook_bootstrap.jl"))
+include(joinpath(@__DIR__, "issue_90_colab_first_cell.jl"))
 
 files_with_qubo_links = [
     "README.md",


### PR DESCRIPTION
## Summary
- keep the Colab bootstrap setup cell focused on resolve and instantiate
- make package warming and explicit precompilation opt-in
- cover the shared setup path used by starter notebooks 7 through 11

## Root cause
After resolving the Julia 1.10 manifest under the hosted Julia 1.12 runtime, the bootstrap dynamically imported every package used by the selected notebook. Disabling that warm-up selected a full `Pkg.precompile()` instead. Both paths add a large package-loading task to the IJulia setup cell even though every starter notebook already has a dedicated top-level import cell.

## Validation
- `make test`
- `python -m unittest discover -s tests` (160 tests)
- `julia +1.10 --startup-file=no test/runtests.jl`
- targeted Julia 1.12 regression (14 tests)
- Julia 1.10 Colab-marked bootstrap smoke
- Julia 1.12.6 manifest-mismatch bootstrap smoke in a clean worktree

The live hosted Colab kernel still needs the manual notebook pass tracked in issue #90.

Refs #90
