### PR TITLE
Reduce Julia Colab first-cell startup time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
     env:
       UV_CACHE_DIR: .uv-cache
       JULIA_DEPOT_PATH: ${{ github.workspace }}/.julia-depot
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -142,15 +142,18 @@ PythonCall to the hosted Python runtime and ensures only `numpy` and `requests`,
 so unrelated Python-backed Julia packages do not expand its setup environment.
 The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
 repository when needed, activate `notebooks_jl`, and select the checked-in
-manifest for the hosted Julia minor version. All Julia notebooks warm their
-declared imports during setup with package output suppressed; set
-`QUBONOTEBOOKS_WARM_PACKAGES=0` to disable that behavior.
-`QUBONOTEBOOKS_PRECOMPILE=1` remains an explicit full-project precompile
-option. `make verify-colab-bootstrap-output JULIA="julia +1.12"` executes the
-real setup and activation cells from all Julia notebooks through IJulia with
-Colab environment markers, plus the dedicated import cell where present. It
-fails on CondaPkg or package/artifact transcripts, manifest mismatch warnings,
-failed-task output, stack traces, cell errors, or unexpected rendered values.
+manifest for the hosted Julia minor version. Automatic full-project
+precompilation and eager import warm-up are disabled during setup so a fresh
+runtime does not front-load compilation for packages the learner may not use.
+Set `QUBONOTEBOOKS_WARM_PACKAGES=1` to warm a notebook's declared imports or
+`QUBONOTEBOOKS_PRECOMPILE=1` to explicitly precompile the full project.
+`make verify-colab-bootstrap-output JULIA="julia +1.12"` executes the real
+setup and activation cells from all Julia notebooks through IJulia with Colab
+environment markers, plus a post-bootstrap package import check. It rejects
+CondaPkg or package/artifact transcripts, manifest mismatch warnings, and pip
+progress in the bootstrap output; later activation and import cells must remain
+free of failed-task output, stack traces, cell errors, and unexpected rendered
+values.
 The smoke provides `pip` only in its isolated runtime so notebooks 2–5 can
 exercise their normal Colab D-Wave setup without adding the Ocean stack to the
 locked project environment.

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -161,7 +161,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/10-QAOA.ipynb
+++ b/notebooks_jl/10-QAOA.ipynb
@@ -108,7 +108,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/11-Annealing.ipynb
+++ b/notebooks_jl/11-Annealing.ipynb
@@ -143,7 +143,7 @@
         "else\n",
         "    Pkg.activate(@__DIR__; io = devnull)\n",
         "end\n",
-        "Pkg.instantiate(; io = devnull)"
+        "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)"
       ]
     },
     {

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -162,7 +162,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -157,7 +157,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -153,7 +153,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -153,7 +153,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)\n"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
    ]
   },
   {

--- a/notebooks_jl/6-QCi.ipynb
+++ b/notebooks_jl/6-QCi.ipynb
@@ -132,7 +132,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)"
    ]
   },
   {

--- a/notebooks_jl/7-CanonicalProblems.ipynb
+++ b/notebooks_jl/7-CanonicalProblems.ipynb
@@ -108,7 +108,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)"
    ]
   },
   {

--- a/notebooks_jl/8-OrderPartitioning.ipynb
+++ b/notebooks_jl/8-OrderPartitioning.ipynb
@@ -112,7 +112,7 @@
     "else\n",
     "    Pkg.activate(@__DIR__; io = devnull)\n",
     "end\n",
-    "Pkg.instantiate(; io = devnull)"
+    "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)"
    ]
   },
   {

--- a/notebooks_jl/9-CancerGenomics.ipynb
+++ b/notebooks_jl/9-CancerGenomics.ipynb
@@ -114,7 +114,7 @@
         "else\n",
         "    Pkg.activate(@__DIR__; io = devnull)\n",
         "end\n",
-        "Pkg.instantiate(; io = devnull)\n"
+        "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)\n"
       ]
     },
     {

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -96,10 +96,7 @@ end
 
 function default_bootstrap_warm_packages(project_key::AbstractString = "")
     configured_warm_packages = env_bool("QUBONOTEBOOKS_WARM_PACKAGES")
-    return something(
-        configured_warm_packages,
-        detect_colab() && haskey(NOTEBOOK_IMPORTS, project_key),
-    )
+    return something(configured_warm_packages, false)
 end
 
 default_bootstrap_precompile() = something(env_bool(PRECOMPILE_ENV), false)
@@ -407,6 +404,7 @@ function configure_python_runtime!(
                     "pip",
                     "install",
                     "-q",
+                    "--progress-bar=off",
                     "--disable-pip-version-check",
                     "--root-user-action=ignore",
                     python_packages...,
@@ -449,11 +447,11 @@ function instantiate_project!(
     log_step("Instantiating Julia packages")
     if in_colab
         with_package_operation_io(in_colab) do pkg_io
-            Pkg.instantiate(; io = pkg_io)
+            Pkg.instantiate(; io = pkg_io, allow_autoprecomp = false)
         end
     else
         @time with_package_operation_io(in_colab) do pkg_io
-            Pkg.instantiate(; io = pkg_io)
+            Pkg.instantiate(; io = pkg_io, allow_autoprecomp = false)
         end
     end
     if precompile

--- a/scripts/verify_colab_bootstrap.py
+++ b/scripts/verify_colab_bootstrap.py
@@ -32,8 +32,13 @@ EXPECTED_COMMON_OUTPUT = (
     "Google Colab runtime detected: true",
     "Manifest Julia version: 1.12.6",
     "Instantiating Julia packages",
-    "Loading notebook packages",
     "Notebook bootstrap complete",
+)
+FATAL_OUTPUT = (
+    (
+        "stack trace or failed-task printer output",
+        re.compile(r"(?i)(?:Stacktrace:|SYSTEM: caught exception)"),
+    ),
 )
 FORBIDDEN_OUTPUT = (
     (
@@ -63,12 +68,16 @@ FORBIDDEN_OUTPUT = (
         re.compile(r"(?i)(?:CondaPkg|micromamba|pixi\.toml)"),
     ),
     (
-        "Julia manifest mismatch warning",
-        re.compile(r"(?i)manifest.+targets Julia.+current kernel"),
+        "eager package warm-up",
+        re.compile(r"(?im)^\s*Loading notebook packages\s*$"),
     ),
     (
-        "stack trace or failed-task printer output",
-        re.compile(r"(?i)(?:Stacktrace:|SYSTEM: caught exception)"),
+        "pip download progress",
+        re.compile(r"(?m)^\s*[━╺╸]{3,}.*$"),
+    ),
+    (
+        "Julia manifest mismatch warning",
+        re.compile(r"(?i)manifest.+targets Julia.+current kernel"),
     ),
 )
 
@@ -152,7 +161,18 @@ def smoke_cell_sources(repo_root: Path, notebook: Path) -> list[str]:
             f"Expected at most one 'imports' cell in {repo_root / notebook}, "
             f"found {len(import_sources)}."
         )
-    return [*sources, *import_sources]
+    if import_sources:
+        return [*sources, *import_sources]
+
+    project_key = notebook.stem
+    warmup_source = (
+        "Base.invokelatest(\n"
+        "    QUBONotebooksBootstrap.warm_notebook_packages!,\n"
+        f'    "{project_key}";\n'
+        "    suppress_logs = true,\n"
+        ");\n"
+    )
+    return [*sources, warmup_source]
 
 
 def output_text(outputs: list[dict]) -> str:
@@ -170,11 +190,7 @@ def concise_line(text: str, *, limit: int = 240) -> str:
     return line[: limit - 3] + "..."
 
 
-def validate_bootstrap_outputs(
-    outputs: list[dict],
-    *,
-    project_key: str = "7-CanonicalProblems",
-) -> str:
+def execution_output_failures(outputs: list[dict]) -> list[str]:
     failures: list[str] = []
     rendered = output_text(outputs)
 
@@ -194,6 +210,32 @@ def validate_bootstrap_outputs(
                     else ""
                 )
             )
+
+    for label, pattern in FATAL_OUTPUT:
+        match = pattern.search(rendered)
+        if match is not None:
+            failures.append(f"{label}: {concise_line(match.group(0))}")
+
+    return failures
+
+
+def validate_execution_outputs(outputs: list[dict]) -> str:
+    failures = execution_output_failures(outputs)
+    if failures:
+        raise AssertionError(
+            "Colab notebook execution validation failed:\n- "
+            + "\n- ".join(failures)
+        )
+    return output_text(outputs)
+
+
+def validate_bootstrap_outputs(
+    outputs: list[dict],
+    *,
+    project_key: str = "7-CanonicalProblems",
+) -> str:
+    failures = execution_output_failures(outputs)
+    rendered = output_text(outputs)
 
     expected_output = (
         f"Notebook project key: {project_key}",
@@ -373,12 +415,15 @@ def main() -> int:
         env.update(
             {
                 "COLAB_RELEASE_TAG": "ci-colab-bootstrap",
-                "JULIA_PKG_PRECOMPILE_AUTO": "0",
-                "QUBONOTEBOOKS_PRECOMPILE": "0",
                 "QUBONOTEBOOKS_REPO_DIR": str(workspace),
             }
         )
-        env.pop("QUBONOTEBOOKS_WARM_PACKAGES", None)
+        for variable in (
+            "JULIA_PKG_PRECOMPILE_AUTO",
+            "QUBONOTEBOOKS_PRECOMPILE",
+            "QUBONOTEBOOKS_WARM_PACKAGES",
+        ):
+            env.pop(variable, None)
         verify_julia_1_12(julia, cwd=workspace, env=env)
         verify_colab_stderr_suppression(
             julia,
@@ -406,8 +451,6 @@ def main() -> int:
                 for key in (
                     "COLAB_RELEASE_TAG",
                     "JULIA_DEPOT_PATH",
-                    "JULIA_PKG_PRECOMPILE_AUTO",
-                    "QUBONOTEBOOKS_PRECOMPILE",
                     "QUBONOTEBOOKS_REPO_DIR",
                 )
                 if key in env
@@ -445,13 +488,15 @@ def main() -> int:
             )
 
             executed = json.loads(executed_notebook.read_text())
-            outputs = [
+            all_outputs = [
                 output
                 for cell in executed["cells"]
                 for output in cell.get("outputs", [])
             ]
+            validate_execution_outputs(all_outputs)
+            bootstrap_outputs = executed["cells"][0].get("outputs", [])
             rendered = validate_bootstrap_outputs(
-                outputs,
+                bootstrap_outputs,
                 project_key=project_key,
             )
             print(f"Captured {project_key} smoke output:", flush=True)

--- a/test/issue_90_colab_bootstrap_output.jl
+++ b/test/issue_90_colab_bootstrap_output.jl
@@ -59,7 +59,7 @@ using Test
     for operation in (
         "Pkg.activate(project_dir; io = pkg_io)",
         "Pkg.update(; io = pkg_io)",
-        "Pkg.instantiate(; io = pkg_io)",
+        "Pkg.instantiate(; io = pkg_io, allow_autoprecomp = false)",
         "Pkg.precompile(; io = pkg_io)",
     )
         has_quiet_colab_operation = occursin(operation, bootstrap_source)

--- a/test/issue_90_colab_cold_start.jl
+++ b/test/issue_90_colab_cold_start.jl
@@ -1,0 +1,51 @@
+using Test
+
+@testset "Issue 90 Colab cold-start policy" begin
+    withenv(
+        "COLAB_RELEASE_TAG" => "issue-90-cold-start",
+        "QUBONOTEBOOKS_WARM_PACKAGES" => nothing,
+    ) do
+        for project_key in keys(QUBONotebooksBootstrap.NOTEBOOK_IMPORTS)
+            @test !QUBONotebooksBootstrap.default_bootstrap_warm_packages(
+                project_key,
+            )
+        end
+    end
+
+    withenv(
+        "COLAB_RELEASE_TAG" => "issue-90-cold-start",
+        "QUBONOTEBOOKS_WARM_PACKAGES" => "true",
+    ) do
+        @test QUBONotebooksBootstrap.default_bootstrap_warm_packages("3-GAMA")
+    end
+
+    bootstrap_source = read(
+        joinpath(repo_root, "scripts", "notebook_bootstrap.jl"),
+        String,
+    )
+    disables_bootstrap_auto_precompile = occursin(
+        "Pkg.instantiate(; io = pkg_io, allow_autoprecomp = false)",
+        bootstrap_source,
+    )
+    disables_pip_progress = occursin(
+        "\"--progress-bar=off\"",
+        bootstrap_source,
+    )
+    @test disables_bootstrap_auto_precompile
+    @test disables_pip_progress
+
+    notebooks_dir = joinpath(repo_root, "notebooks_jl")
+    notebook_paths = filter(
+        path -> endswith(path, ".ipynb"),
+        readdir(notebooks_dir; join = true),
+    )
+    @test length(notebook_paths) == 11
+    for notebook_path in notebook_paths
+        notebook = read(notebook_path, String)
+        disables_activation_auto_precompile = occursin(
+            "Pkg.instantiate(; io = devnull, allow_autoprecomp = false)",
+            notebook,
+        )
+        @test disables_activation_auto_precompile
+    end
+end

--- a/test/issue_90_colab_first_cell.jl
+++ b/test/issue_90_colab_first_cell.jl
@@ -8,7 +8,7 @@ using Test
     ) do
         @test !QUBONotebooksBootstrap.default_bootstrap_warm_packages()
         for project_key in keys(QUBONotebooksBootstrap.NOTEBOOK_IMPORTS)
-            @test QUBONotebooksBootstrap.default_bootstrap_warm_packages(
+            @test !QUBONotebooksBootstrap.default_bootstrap_warm_packages(
                 project_key,
             )
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ repo_root = dirname(@__DIR__)
 include(joinpath(repo_root, "scripts", "notebook_bootstrap.jl"))
 include(joinpath(@__DIR__, "issue_90_colab_first_cell.jl"))
 include(joinpath(@__DIR__, "issue_90_colab_bootstrap_output.jl"))
+include(joinpath(@__DIR__, "issue_90_colab_cold_start.jl"))
 
 files_with_qubo_links = [
     "README.md",

--- a/tests/test_colab_cold_start_contract.py
+++ b/tests/test_colab_cold_start_contract.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "verify_colab_bootstrap.py"
+SPEC = importlib.util.spec_from_file_location("verify_colab_bootstrap", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+verify_colab_bootstrap = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verify_colab_bootstrap)
+
+
+def concise_bootstrap_output(*extra_lines: str) -> list[dict]:
+    lines = [
+        "[12:00:00] Notebook project key: 3-GAMA",
+        "[12:00:00] Google Colab runtime detected: true",
+        "[12:00:00] Manifest Julia version: 1.12.6",
+        "[12:00:00] Instantiating Julia packages",
+        *extra_lines,
+        "[12:00:00] Notebook bootstrap complete",
+    ]
+    return [
+        {
+            "name": "stdout",
+            "output_type": "stream",
+            "text": ["\n".join(lines) + "\n"],
+        }
+    ]
+
+
+class ColabColdStartContractTests(unittest.TestCase):
+    def test_default_bootstrap_output_does_not_require_eager_warmup(self) -> None:
+        rendered = verify_colab_bootstrap.validate_bootstrap_outputs(
+            concise_bootstrap_output(),
+            project_key="3-GAMA",
+        )
+
+        self.assertNotIn("Loading notebook packages", rendered)
+
+    def test_rejects_eager_warmup_and_pip_progress(self) -> None:
+        noisy_outputs = (
+            ("Loading notebook packages", "eager package warm-up"),
+            (
+                "   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.7/8.7 MB",
+                "pip download progress",
+            ),
+        )
+
+        for output, expected_error in noisy_outputs:
+            with self.subTest(output=output):
+                with self.assertRaisesRegex(AssertionError, expected_error):
+                    verify_colab_bootstrap.validate_bootstrap_outputs(
+                        concise_bootstrap_output(output),
+                        project_key="3-GAMA",
+                    )
+
+    def test_smoke_does_not_force_precompile_environment_override(self) -> None:
+        main_source = inspect.getsource(verify_colab_bootstrap.main)
+        forces_precompile_override = (
+            '"JULIA_PKG_PRECOMPILE_AUTO": "0"' in main_source
+        )
+
+        self.assertFalse(forces_precompile_override)
+
+    def test_post_bootstrap_cells_remain_error_checked(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "cell error: ErrorException"):
+            verify_colab_bootstrap.validate_execution_outputs(
+                [
+                    {
+                        "ename": "ErrorException",
+                        "evalue": "deferred import failed",
+                        "output_type": "error",
+                        "traceback": ["large traceback intentionally ignored"],
+                    }
+                ]
+            )
+
+    def test_every_notebook_activation_disables_auto_precompile(self) -> None:
+        missing_activation_guard = []
+        duplicate_activation_guard = []
+        for notebook_path in verify_colab_bootstrap.NOTEBOOK_PATHS:
+            notebook = json.loads((REPO_ROOT / notebook_path).read_text())
+            activation_source = verify_colab_bootstrap.activation_cell_source(
+                REPO_ROOT,
+                notebook_path,
+            )
+            guard_count = sum(
+                "allow_autoprecomp = false" in "".join(cell.get("source", []))
+                for cell in notebook["cells"]
+            )
+
+            if "allow_autoprecomp = false" not in activation_source:
+                missing_activation_guard.append(notebook_path.as_posix())
+            if guard_count != 1:
+                duplicate_activation_guard.append(
+                    (notebook_path.as_posix(), guard_count)
+                )
+
+        self.assertEqual(11, len(verify_colab_bootstrap.NOTEBOOK_PATHS))
+        self.assertEqual([], missing_activation_guard)
+        self.assertEqual([], duplicate_activation_guard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_colab_bootstrap.py
+++ b/tests/test_verify_colab_bootstrap.py
@@ -26,7 +26,6 @@ def clean_outputs() -> list[dict]:
                     "[12:00:00] Google Colab runtime detected: true",
                     "[12:00:00] Manifest Julia version: 1.12.6",
                     "[12:00:00] Instantiating Julia packages",
-                    "[12:00:00] Loading notebook packages",
                     "[12:00:00] Notebook bootstrap complete",
                 ]
             )
@@ -74,11 +73,11 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
                     notebook_path,
                 )
 
-                self.assertIn(len(sources), (2, 3))
+                self.assertEqual(3, len(sources))
                 self.assertIn("bootstrap_notebook", sources[0])
                 self.assertIn("Pkg.instantiate", sources[1])
                 self.assertIn("io = devnull", sources[1])
-                if len(sources) == 3:
+                if "warm_notebook_packages!" not in sources[2]:
                     self.assertIn("using JuMP", sources[2])
 
     def test_accepts_only_concise_bootstrap_output(self) -> None:


### PR DESCRIPTION
## Summary

- disable Julia Pkg automatic precompilation during the shared bootstrap and every notebook activation cell
- make eager notebook import warm-up opt-in instead of the Colab default
- disable pip progress bars while preserving concise Python package setup milestones
- make the Colab smoke exercise realistic environment defaults, validate first-cell output separately, and still execute post-bootstrap imports

## Acceptance criteria

- [x] All 11 Julia notebooks pass `allow_autoprecomp = false` to their activation-cell `Pkg.instantiate`.
- [x] The shared bootstrap instantiates without automatic precompilation and retains `QUBONOTEBOOKS_PRECOMPILE=1` as the explicit full-project option.
- [x] `QUBONOTEBOOKS_WARM_PACKAGES=1` remains available, while the default no longer loads notebook packages in the first cell.
- [x] Colab pip installs use `--progress-bar=off`.
- [x] The smoke no longer injects `JULIA_PKG_PRECOMPILE_AUTO=0`, rejects eager warm-up and pip progress in bootstrap output, and checks deferred activation/import cells for errors.

## Verification

- `julia +1.10 --startup-file=no test/runtests.jl`
- `julia +1.12 --startup-file=no test/runtests.jl`
- `.venv/bin/python -m unittest discover -s tests` — 180 passed
- `make verify-colab-bootstrap-output JULIA="julia +1.12"` — all 11 bootstrap and import smokes passed
- `actionlint .github/workflows/ci.yml`
- `make test`
- `git diff --check`

The regression tests were first run red against the merged behavior. Isolated mutation checks also failed when eager warm-up, either automatic-precompile guard, pip suppression, or pip-progress detection was removed.

## Notebook outputs

Saved outputs were intentionally not re-executed. Each notebook change is limited to the shared activation-cell policy; the complete smoke executes those exact cells through IJulia.

## Branch hygiene

- Base: `main` at `1cecd9a55e3d4b469dede024b2b0f90f529fd6a7`
- Head: `fix/issue-90-colab-cold-start`
- Not stacked; no open overlapping PRs were found before push.

## Remaining scope

This PR shortens and cleans the first-cell path, but a completely fresh Colab runtime must still download the shared 358-package environment. Splitting that environment per notebook is a larger dependency and lockfile redesign and is intentionally deferred.

Refs #90
