### PR TITLE
Fix Python-backed Julia Colab imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,13 @@ does not have a locked local make target because `eqc-models==0.19.0` requires
 specific to the Python notebook. The Julia counterpart does not install the
 Python `qci-client` distribution: QCIOpt uses its default CondaPkg environment
 and coexists with DWave and NetworkX 3 in the shared Julia project, guarded by
-`make test-qciopt-dwave-coexistence`. In native Colab, notebook 6 instead binds
-PythonCall to the hosted Python runtime and ensures only `numpy` and `requests`,
-so unrelated Python-backed Julia packages do not expand its setup environment.
+`make test-qciopt-dwave-coexistence`. In native Colab, every Python-backed Julia
+notebook binds PythonCall to the hosted Python runtime before Julia package
+instantiation. Notebooks 2–5, 9, and 11 ensure the Ocean stack, notebook 6
+ensures only `numpy` and `requests`, and notebook 10 requests QiskitOpt's
+versioned Qiskit, Aer, IBM Runtime, Optimization, and SciPy stack (plus their
+transitive dependencies). This keeps unrelated dependencies from the shared
+Julia project's CondaPkg environment out of deferred import cells.
 The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
 repository when needed, activate `notebooks_jl`, and select the checked-in
 manifest for the hosted Julia minor version. Automatic full-project
@@ -152,8 +156,8 @@ setup and activation cells from all Julia notebooks through IJulia with Colab
 environment markers, plus a post-bootstrap package import check. It rejects
 CondaPkg or package/artifact transcripts, manifest mismatch warnings, and pip
 progress in the bootstrap output; later activation and import cells must remain
-free of failed-task output, stack traces, cell errors, and unexpected rendered
-values.
+free of CondaPkg environment setup, failed-task output, stack traces, cell
+errors, and unexpected rendered values.
 The smoke provides `pip` only in its isolated runtime so notebooks 2–5 can
 exercise their normal Colab D-Wave setup without adding the Ocean stack to the
 locked project environment.

--- a/README.md
+++ b/README.md
@@ -144,20 +144,27 @@ ensures only `numpy` and `requests`, and notebook 10 requests QiskitOpt's
 versioned Qiskit, Aer, IBM Runtime, Optimization, and SciPy stack (plus their
 transitive dependencies). This keeps unrelated dependencies from the shared
 Julia project's CondaPkg environment out of deferred import cells.
+On a cold Julia 1.12 IJulia kernel, QCIOpt, QiskitOpt, and the
+IJulia/PythonCall extension can otherwise emit failed-task-printer notices
+during their first implicit compilation even when the imports succeed.
+Notebooks 6 and 10 therefore perform one narrow, output-suppressed first load
+during setup; the other notebooks keep their package imports deferred.
 The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
 repository when needed, activate `notebooks_jl`, and select the checked-in
 manifest for the hosted Julia minor version. Automatic full-project
-precompilation and eager import warm-up are disabled during setup so a fresh
-runtime does not front-load compilation for packages the learner may not use.
+precompilation and broad eager import warm-up are disabled during setup so a
+fresh runtime does not front-load compilation for packages the learner may not
+use.
 Set `QUBONOTEBOOKS_WARM_PACKAGES=1` to warm a notebook's declared imports or
 `QUBONOTEBOOKS_PRECOMPILE=1` to explicitly precompile the full project.
 `make verify-colab-bootstrap-output JULIA="julia +1.12"` executes the real
 setup and activation cells from all Julia notebooks through IJulia with Colab
 environment markers, plus a post-bootstrap package import check. It rejects
 CondaPkg or package/artifact transcripts, manifest mismatch warnings, and pip
-progress in the bootstrap output; later activation and import cells must remain
-free of CondaPkg environment setup, failed-task output, stack traces, cell
-errors, and unexpected rendered values.
+progress in the bootstrap output. It also requires the narrow notebook 6 and 10
+first-load workaround; later activation and import cells must remain free of
+CondaPkg environment setup, failed-task output, stack traces, cell errors, and
+unexpected rendered values.
 The smoke provides `pip` only in its isolated runtime so notebooks 2–5 can
 exercise their normal Colab D-Wave setup without adding the Ocean stack to the
 locked project environment.

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -23,6 +23,10 @@ const CREDENTIAL_FREE_DWAVE_NOTEBOOKS = Set((
 const CREDENTIAL_FREE_QCI_NOTEBOOKS = Set((
     "6-QCi",
 ))
+const COLAB_IJULIA_PYTHON_PRELOAD_NOTEBOOKS = Set((
+    "6-QCi",
+    "10-QAOA",
+))
 const COLAB_SYSTEM_PYTHON_PACKAGES = Dict(
     "6-QCi" => ["numpy", "requests"],
     "9-CancerGenomics" => ["dwave-ocean-sdk"],
@@ -109,6 +113,10 @@ function default_bootstrap_warm_packages(project_key::AbstractString = "")
 end
 
 default_bootstrap_precompile() = something(env_bool(PRECOMPILE_ENV), false)
+requires_colab_python_preload(
+    project_key::AbstractString;
+    in_colab::Bool = detect_colab(),
+) = in_colab && project_key in COLAB_IJULIA_PYTHON_PRELOAD_NOTEBOOKS
 
 function notebook_key(target::AbstractString)
     return splitext(basename(target))[1]
@@ -566,6 +574,8 @@ function bootstrap_notebook(
     )
     if warm_packages
         warm_notebook_packages!(project_key; suppress_logs = suppress_warmup_logs)
+    elseif requires_colab_python_preload(project_key; in_colab = in_colab)
+        warm_notebook_packages!(project_key; suppress_logs = true)
     end
 
     if chdir_to_notebooks

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -25,6 +25,15 @@ const CREDENTIAL_FREE_QCI_NOTEBOOKS = Set((
 ))
 const COLAB_SYSTEM_PYTHON_PACKAGES = Dict(
     "6-QCi" => ["numpy", "requests"],
+    "9-CancerGenomics" => ["dwave-ocean-sdk"],
+    "10-QAOA" => [
+        "qiskit~=2.3.0",
+        "qiskit-aer~=0.17.0",
+        "qiskit-ibm-runtime~=0.46.0",
+        "qiskit-optimization~=0.7.0",
+        "scipy~=1.15.0",
+    ],
+    "11-Annealing" => ["dwave-ocean-sdk"],
 )
 const PYTHON_PACKAGE_IMPORT_NAMES = Dict(
     "dwave-ocean-sdk" => "dwave",
@@ -110,10 +119,20 @@ function notebook_requires_python(project_key::AbstractString)
 end
 
 notebook_import_expr(project_key::AbstractString) = get(NOTEBOOK_IMPORTS, project_key, nothing)
-python_import_name(package::AbstractString) =
-    get(PYTHON_PACKAGE_IMPORT_NAMES, package, replace(package, "-" => "_"))
+python_distribution_name(package::AbstractString) =
+    strip(first(split(package, r"[<>=!~]"; limit = 2)))
+python_import_name(package::AbstractString) = begin
+    distribution = python_distribution_name(package)
+    return get(
+        PYTHON_PACKAGE_IMPORT_NAMES,
+        distribution,
+        replace(distribution, "-" => "_"),
+    )
+end
 python_import_statement(python_packages::Vector{String}) =
     "import " * join(python_import_name.(python_packages), ", ")
+has_python_version_constraint(package::AbstractString) =
+    python_distribution_name(package) != strip(package)
 
 function notebook_project_dir(; repo_dir::AbstractString = WORKSPACE)
     return joinpath(repo_dir, NOTEBOOKS_DIRNAME)
@@ -397,7 +416,11 @@ function configure_python_runtime!(
                 stdout = devnull,
                 stderr = devnull,
             )
-            if !success(import_check)
+            packages_need_version_check = any(
+                has_python_version_constraint,
+                python_packages,
+            )
+            if packages_need_version_check || !success(import_check)
                 run(Cmd([
                     python_exe,
                     "-m",

--- a/scripts/verify_colab_bootstrap.py
+++ b/scripts/verify_colab_bootstrap.py
@@ -34,6 +34,7 @@ EXPECTED_COMMON_OUTPUT = (
     "Instantiating Julia packages",
     "Notebook bootstrap complete",
 )
+COLAB_IJULIA_PYTHON_PRELOAD_NOTEBOOKS = frozenset(("6-QCi", "10-QAOA"))
 EXECUTION_FORBIDDEN_OUTPUT = (
     (
         "stack trace or failed-task printer output",
@@ -66,10 +67,6 @@ FORBIDDEN_OUTPUT = (
             r"(?im)^\s*(?:Activating project at|Resolving package versions|"
             r"(?:\[ Info:\s*)?Precompiling\b)"
         ),
-    ),
-    (
-        "eager package warm-up",
-        re.compile(r"(?im)^\s*Loading notebook packages\s*$"),
     ),
     (
         "pip download progress",
@@ -249,6 +246,13 @@ def validate_bootstrap_outputs(
         match = pattern.search(rendered)
         if match is not None:
             failures.append(f"{label}: {concise_line(match.group(0))}")
+
+    warmup_message = "Loading notebook packages"
+    if project_key in COLAB_IJULIA_PYTHON_PRELOAD_NOTEBOOKS:
+        if warmup_message not in rendered:
+            failures.append(f"missing milestone: {warmup_message}")
+    elif warmup_message in rendered:
+        failures.append(f"unexpected eager package warm-up: {warmup_message}")
 
     if failures:
         raise AssertionError(

--- a/scripts/verify_colab_bootstrap.py
+++ b/scripts/verify_colab_bootstrap.py
@@ -34,10 +34,14 @@ EXPECTED_COMMON_OUTPUT = (
     "Instantiating Julia packages",
     "Notebook bootstrap complete",
 )
-FATAL_OUTPUT = (
+EXECUTION_FORBIDDEN_OUTPUT = (
     (
         "stack trace or failed-task printer output",
         re.compile(r"(?i)(?:Stacktrace:|SYSTEM: caught exception)"),
+    ),
+    (
+        "CondaPkg environment setup",
+        re.compile(r"(?i)(?:CondaPkg|micromamba|\bpixi\b|/\.CondaPkg)"),
     ),
 )
 FORBIDDEN_OUTPUT = (
@@ -62,10 +66,6 @@ FORBIDDEN_OUTPUT = (
             r"(?im)^\s*(?:Activating project at|Resolving package versions|"
             r"(?:\[ Info:\s*)?Precompiling\b)"
         ),
-    ),
-    (
-        "CondaPkg environment setup",
-        re.compile(r"(?i)(?:CondaPkg|micromamba|pixi\.toml)"),
     ),
     (
         "eager package warm-up",
@@ -211,7 +211,7 @@ def execution_output_failures(outputs: list[dict]) -> list[str]:
                 )
             )
 
-    for label, pattern in FATAL_OUTPUT:
+    for label, pattern in EXECUTION_FORBIDDEN_OUTPUT:
         match = pattern.search(rendered)
         if match is not None:
             failures.append(f"{label}: {concise_line(match.group(0))}")

--- a/test/issue_90_colab_first_cell.jl
+++ b/test/issue_90_colab_first_cell.jl
@@ -28,14 +28,45 @@ using Test
     @test !QUBONotebooksBootstrap.notebook_requires_python("6-QCi")
     @test !QUBONotebooksBootstrap.notebook_requires_python("10-QAOA")
     @test QUBONotebooksBootstrap.notebook_requires_python("2-QUBO")
-    @test QUBONotebooksBootstrap.COLAB_SYSTEM_PYTHON_PACKAGES["6-QCi"] ==
-        ["numpy", "requests"]
+    qaoa_python_packages = [
+        "qiskit~=2.3.0",
+        "qiskit-aer~=0.17.0",
+        "qiskit-ibm-runtime~=0.46.0",
+        "qiskit-optimization~=0.7.0",
+        "scipy~=1.15.0",
+    ]
+    @test get(
+        QUBONotebooksBootstrap.COLAB_SYSTEM_PYTHON_PACKAGES,
+        "6-QCi",
+        nothing,
+    ) == ["numpy", "requests"]
+    @test get(
+        QUBONotebooksBootstrap.COLAB_SYSTEM_PYTHON_PACKAGES,
+        "9-CancerGenomics",
+        nothing,
+    ) == ["dwave-ocean-sdk"]
+    @test get(
+        QUBONotebooksBootstrap.COLAB_SYSTEM_PYTHON_PACKAGES,
+        "10-QAOA",
+        nothing,
+    ) == qaoa_python_packages
+    @test get(
+        QUBONotebooksBootstrap.COLAB_SYSTEM_PYTHON_PACKAGES,
+        "11-Annealing",
+        nothing,
+    ) == ["dwave-ocean-sdk"]
     @test QUBONotebooksBootstrap.python_import_statement(
         ["dwave-ocean-sdk"],
     ) == "import dwave"
     @test QUBONotebooksBootstrap.python_import_statement(
         ["numpy", "requests"],
     ) == "import numpy, requests"
+    @test QUBONotebooksBootstrap.python_import_statement(
+        qaoa_python_packages,
+    ) ==
+        "import qiskit, qiskit_aer, qiskit_ibm_runtime, qiskit_optimization, scipy"
+    @test QUBONotebooksBootstrap.has_python_version_constraint("qiskit~=2.3.0")
+    @test !QUBONotebooksBootstrap.has_python_version_constraint("requests")
 
     for project_key in keys(QUBONotebooksBootstrap.NOTEBOOK_IMPORTS)
         notebook = read(

--- a/test/issue_90_colab_first_cell.jl
+++ b/test/issue_90_colab_first_cell.jl
@@ -28,6 +28,20 @@ using Test
     @test !QUBONotebooksBootstrap.notebook_requires_python("6-QCi")
     @test !QUBONotebooksBootstrap.notebook_requires_python("10-QAOA")
     @test QUBONotebooksBootstrap.notebook_requires_python("2-QUBO")
+    for project_key in ("6-QCi", "10-QAOA")
+        @test QUBONotebooksBootstrap.requires_colab_python_preload(
+            project_key;
+            in_colab = true,
+        )
+        @test !QUBONotebooksBootstrap.requires_colab_python_preload(
+            project_key;
+            in_colab = false,
+        )
+    end
+    @test !QUBONotebooksBootstrap.requires_colab_python_preload(
+        "3-GAMA";
+        in_colab = true,
+    )
     qaoa_python_packages = [
         "qiskit~=2.3.0",
         "qiskit-aer~=0.17.0",

--- a/tests/test_qaoa_colab_python_runtime.py
+++ b/tests/test_qaoa_colab_python_runtime.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "verify_colab_bootstrap.py"
+SPEC = importlib.util.spec_from_file_location("verify_colab_bootstrap", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+verify_colab_bootstrap = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verify_colab_bootstrap)
+
+
+def stream(text: str) -> dict:
+    return {"name": "stderr", "output_type": "stream", "text": [text]}
+
+
+class QAOAColabPythonRuntimeTests(unittest.TestCase):
+    def test_rejects_condapkg_setup_from_deferred_import_cells(self) -> None:
+        environment_setup_samples = (
+            "    CondaPkg Resolving changes\n",
+            " Downloading artifact: micromamba\n",
+            " Downloading artifact: pixi\n",
+            "             └ /content/QUBONotebooks/notebooks_jl/.CondaPkg\n",
+            "✔ Created /content/QUBONotebooks/notebooks_jl/.CondaPkg/pixi.toml\n",
+        )
+
+        for output in environment_setup_samples:
+            with self.subTest(output=output):
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    "CondaPkg environment setup",
+                ):
+                    verify_colab_bootstrap.validate_execution_outputs(
+                        [stream(output)]
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qaoa_colab_python_runtime.py
+++ b/tests/test_qaoa_colab_python_runtime.py
@@ -17,6 +17,19 @@ def stream(text: str) -> dict:
     return {"name": "stderr", "output_type": "stream", "text": [text]}
 
 
+def qaoa_bootstrap_outputs(*, warm_packages: bool) -> list[dict]:
+    lines = [
+        "[12:00:00] Notebook project key: 10-QAOA",
+        "[12:00:00] Google Colab runtime detected: true",
+        "[12:00:00] Manifest Julia version: 1.12.6",
+        "[12:00:00] Instantiating Julia packages",
+    ]
+    if warm_packages:
+        lines.append("[12:00:00] Loading notebook packages")
+    lines.append("[12:00:00] Notebook bootstrap complete")
+    return [stream("\n".join(lines) + "\n")]
+
+
 class QAOAColabPythonRuntimeTests(unittest.TestCase):
     def test_rejects_condapkg_setup_from_deferred_import_cells(self) -> None:
         environment_setup_samples = (
@@ -36,6 +49,19 @@ class QAOAColabPythonRuntimeTests(unittest.TestCase):
                     verify_colab_bootstrap.validate_execution_outputs(
                         [stream(output)]
                     )
+
+    def test_requires_the_narrow_qaoa_import_workaround(self) -> None:
+        rendered = verify_colab_bootstrap.validate_bootstrap_outputs(
+            qaoa_bootstrap_outputs(warm_packages=True),
+            project_key="10-QAOA",
+        )
+
+        self.assertIn("Loading notebook packages", rendered)
+        with self.assertRaisesRegex(AssertionError, "missing milestone"):
+            verify_colab_bootstrap.validate_bootstrap_outputs(
+                qaoa_bootstrap_outputs(warm_packages=False),
+                project_key="10-QAOA",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- bind every Python-backed Julia notebook to Colab's hosted Python runtime before Julia package instantiation
- provision notebook 10 with the versioned Python stack declared by QiskitOpt 0.7.1 instead of allowing CondaPkg to aggregate the shared Julia project's unrelated dependencies
- preload only QCIOpt and QiskitOpt during cold Julia 1.12 Colab setup, suppressing erroneous IJulia failed-task-printer notices before their deferred import cells
- extend the Colab smoke contract so CondaPkg, micromamba, pixi, stack traces, or failed-task notices in any executed cell fail CI

This follows up on #113: deferring package imports shortened the first cell, but it exposed previously hidden CondaPkg setup in notebook 10's import cell. The full smoke showed that notebooks 9 and 11 had the same latent Python-runtime path, so the central mapping covers them too. A cold CI run also exposed Julia 1.12 IJulia precompile-printer noise for QCIOpt; notebooks 6 and 10 now use a narrow, log-suppressed preload while broad eager loading remains disabled.

## Acceptance criteria

- [x] Notebook 10 configures PythonCall before `Pkg.instantiate`.
- [x] Notebook 10 requests QiskitOpt's Qiskit/Aer/IBM Runtime/Optimization/SciPy versions on Colab.
- [x] Python-backed notebooks 2–6 and 9–11 use the hosted Python runtime rather than the shared CondaPkg environment.
- [x] Only notebooks 6 and 10 receive the cold Julia 1.12 IJulia preload workaround.
- [x] Every executed cell rejects CondaPkg, micromamba, pixi, failed-task, stack-trace, and cell-error output.
- [x] No notebook source or committed notebook output changes are required; the shared bootstrap applies the fix to every notebook.

## Verification

- `.venv/bin/python -m unittest discover -s tests` — 182 passed
- `julia +1.10 --startup-file=no test/runtests.jl` — all testsets passed
- `julia +1.12 --startup-file=no test/runtests.jl` — all testsets passed
- `make test` — passed
- `make verify-qaoa-julia-local` — executed notebook 10 successfully
- isolated cold Julia 1.12 IJulia smoke — notebooks 6 and 10 completed setup and deferred imports cleanly in about 34s and 29s, respectively
- Colab/IJulia smoke for notebooks 9, 10, and 11 — setup and deferred imports passed with no forbidden output
- Python 3.12 QiskitOpt runtime probe — Qiskit 2.3.1, Qiskit Aer 0.17.2, Qiskit Optimization 0.7.0, and the local Aer backend passed
- regression proof against `origin/main` — the new checks fail for missing notebook 9–11 mappings, unparsed version constraints, all five deferred CondaPkg/micromamba/pixi output samples, and the cold Julia 1.12 failed-task notices

## Branch hygiene

- based on `origin/main` at `48d6ed2d2f9b9eedd87011352a03828801dcc9a3`
- two focused implementation commits
- no manifest, lockfile, notebook source, or saved-output changes

Refs #90
