### PR TITLE
Fix real Colab import-cell coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ verify-five-starter-problems-julia-local:
 	QUBONOTEBOOKS_QAOA_ENABLE_IBM=0 QUBONOTEBOOKS_QAOA_REQUIRE_IBM=0 QUBONOTEBOOKS_ANNEALING_ENABLE_QPU=0 QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU=0 $(MAKE) verify-notebooks UV_GROUP_FLAGS="--group docs" NOTEBOOKS="$(FIVE_STARTER_JULIA_NOTEBOOKS)"
 
 verify-colab-bootstrap-output:
-	JULIA_BIN="$(JULIA)" UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run --locked --group docs --with numpy --with requests --with pip python ./scripts/verify_colab_bootstrap.py
+	JULIA_BIN="$(JULIA)" UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run --locked --group docs --with matplotlib --with numpy --with requests --with pip python ./scripts/verify_colab_bootstrap.py
 
 verify-colab-hosted:
 	$(PYTHON) ./scripts/verify_hosted_colab.py

--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ cells.
 On a cold Julia 1.12 IJulia kernel, QCIOpt, QiskitOpt, and the
 IJulia/PythonCall extension can otherwise emit failed-task-printer notices
 during their first implicit compilation even when the imports succeed.
-Every notebook keeps package loading out of the default bootstrap. Notebooks
-6–11 route their explicit import cells through the shared output-suppressed
-loader, while notebooks 1–5 retain their lesson-scoped deferred imports. Real
-package-load failures still propagate from the helper.
+Every notebook keeps package loading out of the default bootstrap and routes
+each real import cell through the shared Colab-aware output-suppressed loader.
+Notebooks 1–5 retain their lesson-scoped deferred import boundaries, while
+notebooks 6–11 load one declared package group. Real package-load failures
+still propagate from the helper.
 The Julia notebooks use `scripts/notebook_bootstrap.jl` in Colab to clone the
 repository when needed, activate `notebooks_jl`, and select the checked-in
 manifest for the hosted Julia minor version. Automatic full-project
@@ -165,16 +166,16 @@ use.
 Set `QUBONOTEBOOKS_WARM_PACKAGES=1` to warm a notebook's declared imports or
 `QUBONOTEBOOKS_PRECOMPILE=1` to explicitly precompile the full project.
 `make verify-colab-bootstrap-output JULIA="julia +1.12"` executes the real
-setup and activation cells from all Julia notebooks through IJulia with Colab
-environment markers, plus a post-bootstrap package import check. It rejects
+setup, activation, and every marked real import cell from all Julia notebooks
+through fresh IJulia kernels with Colab environment markers. It rejects
 CondaPkg or package/artifact transcripts, manifest mismatch warnings, and pip
-progress in the bootstrap output. It then executes every notebook's declared
-post-bootstrap import set; activation and import cells must remain free of
+progress in the bootstrap output. No synthetic aggregate import is substituted;
+activation and import cells must remain free of
 CondaPkg environment setup, failed-task output, stack traces, cell errors, and
 unexpected rendered values.
-The smoke provides `pip` only in its isolated runtime so notebooks 2–5 can
-exercise their normal Colab D-Wave setup without adding the Ocean stack to the
-locked project environment.
+The smoke provides `pip`, Matplotlib, NumPy, and requests only in its isolated
+runtime so notebooks can exercise Colab's preinstalled Python baseline without
+adding the Ocean stack to the locked project environment.
 
 For a cold test on Google's current hosted image, install the official Colab
 CLI and run the hosted target after pushing the commit under test:
@@ -184,13 +185,14 @@ uv tool install --force git+https://github.com/googlecolab/google-colab-cli
 make verify-colab-hosted
 ```
 
-The first invocation that contacts Colab prompts for Google OAuth. The target
-creates a fresh hosted CPU VM, fetches the exact current Git commit, executes
-the real bootstrap, activation, and import cells through Colab's native `julia`
-kernelspec, rejects CondaPkg setup and failed-task output, rejects bootstrap
-cells slower than three minutes, and releases the VM when the command finishes.
-It tests `11-Annealing` by default; select any committed notebook keys with, for
-example,
+The first invocation that contacts Colab prompts for Google OAuth. By default,
+the target tests all 11 Julia notebooks in separate fresh hosted CPU VMs so one
+notebook's compiled package cache cannot hide another notebook's cold-start
+behavior. Each invocation fetches the exact current Git commit, executes the
+real bootstrap, activation, and marked import cells through Colab's native
+`julia` kernelspec, rejects CondaPkg setup and failed-task output, rejects
+bootstrap cells slower than three minutes, and releases its VM when the command
+finishes. Select a narrower set of committed notebook keys with, for example,
 
 ```bash
 QUBONOTEBOOKS_COLAB_NOTEBOOKS="9-CancerGenomics,11-Annealing" \
@@ -198,7 +200,9 @@ QUBONOTEBOOKS_COLAB_NOTEBOOKS="9-CancerGenomics,11-Annealing" \
 ```
 
 The hosted target consumes Colab quota and is intentionally an explicit
-maintainer acceptance test rather than part of ordinary GitHub Actions.
+maintainer acceptance test rather than part of ordinary GitHub Actions. A
+multi-notebook selection still uses one auto-released VM per notebook and can
+therefore take substantially longer than a single-notebook check.
 
 ```bash
 make verify-notebooks NOTEBOOKS="notebooks_py/2-QUBO_python.ipynb" UV_GROUP_FLAGS="--group docs --group qubo"

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -245,12 +245,18 @@
      "iopub.status.busy": "2026-07-10T17:49:22.022000Z",
      "iopub.status.idle": "2026-07-10T17:49:23.445000Z",
      "shell.execute_reply": "2026-07-10T17:49:23.445000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-plots"
    },
    "outputs": [],
    "source": [
     "# Loading in the Plots Package\n",
-    "using Plots"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Plots\",\n",
+    "    :(using Plots),\n",
+    ");\n"
    ]
   },
   {
@@ -352,12 +358,18 @@
      "iopub.status.busy": "2026-07-10T17:49:26.947000Z",
      "iopub.status.idle": "2026-07-10T17:49:27.647000Z",
      "shell.execute_reply": "2026-07-10T17:49:27.646000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-jump"
    },
    "outputs": [],
    "source": [
     "# Loading in the modeling framework JuMP\n",
-    "using JuMP"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"JuMP\",\n",
+    "    :(using JuMP),\n",
+    ");\n"
    ]
   },
   {
@@ -416,12 +428,18 @@
      "iopub.status.busy": "2026-07-10T17:49:28.612000Z",
      "iopub.status.idle": "2026-07-10T17:49:28.665000Z",
      "shell.execute_reply": "2026-07-10T17:49:28.665000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-glpk"
    },
    "outputs": [],
    "source": [
     "# Loading in the GLPK solver\n",
-    "using GLPK"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"GLPK\",\n",
+    "    :(using GLPK),\n",
+    ");\n"
    ]
   },
   {
@@ -498,12 +516,18 @@
      "iopub.status.busy": "2026-07-10T17:49:31.303000Z",
      "iopub.status.idle": "2026-07-10T17:49:31.387000Z",
      "shell.execute_reply": "2026-07-10T17:49:31.387000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-cbc"
    },
    "outputs": [],
    "source": [
     "# Loading in the CBC solver\n",
-    "using Cbc"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Cbc\",\n",
+    "    :(using Cbc),\n",
+    ");\n"
    ]
   },
   {
@@ -605,12 +629,18 @@
      "iopub.status.busy": "2026-07-10T17:49:37.552000Z",
      "iopub.status.idle": "2026-07-10T17:49:37.760000Z",
      "shell.execute_reply": "2026-07-10T17:49:37.760000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-ipopt"
    },
    "outputs": [],
    "source": [
     "# Loading in the Ipopt solver\n",
-    "using Ipopt"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Ipopt\",\n",
+    "    :(using Ipopt),\n",
+    ");\n"
    ]
   },
   {
@@ -1005,12 +1035,18 @@
      "iopub.status.busy": "2026-07-10T17:49:45.708000Z",
      "iopub.status.idle": "2026-07-10T17:49:45.709000Z",
      "shell.execute_reply": "2026-07-10T17:49:45.708000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-specialfunctions"
    },
    "outputs": [],
    "source": [
     "# Loading in SpecialFunctions package that provides a range of mathematical functions\n",
-    "using SpecialFunctions"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"SpecialFunctions\",\n",
+    "    :(using SpecialFunctions),\n",
+    ");\n"
    ]
   },
   {
@@ -1259,6 +1295,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-bonmin"
+   },
+   "outputs": [],
+   "source": [
+    "# BONMIN Solver\n",
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"AmplNLWriter and Bonmin\",\n",
+    "    :(begin\n",
+    "        using AmplNLWriter\n",
+    "        using Bonmin_jll\n",
+    "    end),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 21,
    "metadata": {
     "execution": {
@@ -1270,11 +1326,7 @@
    },
    "outputs": [],
    "source": [
-    "# BONMIN Solver\n",
-    "using AmplNLWriter\n",
-    "using Bonmin_jll\n",
-    "\n",
-    "Bonmin_Optimizer() = AmplNLWriter.Optimizer(Bonmin_jll.amplexe);"
+    "Bonmin_Optimizer() = AmplNLWriter.Optimizer(Bonmin_jll.amplexe);\n"
    ]
   },
   {
@@ -1643,6 +1695,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-couenne"
+   },
+   "outputs": [],
+   "source": [
+    "# COUENNE Solver\n",
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Couenne\",\n",
+    "    :(using Couenne_jll),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 27,
    "metadata": {
     "execution": {
@@ -1654,10 +1723,7 @@
    },
    "outputs": [],
    "source": [
-    "# COUENNE Solver\n",
-    "using Couenne_jll\n",
-    "\n",
-    "Couenne_Optimizer() = AmplNLWriter.Optimizer(Couenne_jll.amplexe);"
+    "Couenne_Optimizer() = AmplNLWriter.Optimizer(Couenne_jll.amplexe);\n"
    ]
   },
   {

--- a/notebooks_jl/10-QAOA.ipynb
+++ b/notebooks_jl/10-QAOA.ipynb
@@ -148,13 +148,15 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "imports",
-   "metadata": {},
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports"
+   },
    "outputs": [],
    "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
     "Base.invokelatest(\n",
     "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-    "    \"10-QAOA\";\n",
-    "    suppress_logs = true,\n",
+    "    \"10-QAOA\",\n",
     ");\n"
    ]
   },

--- a/notebooks_jl/11-Annealing.ipynb
+++ b/notebooks_jl/11-Annealing.ipynb
@@ -215,15 +215,16 @@
           "iopub.status.busy": "2026-07-23T20:40:06.529000Z",
           "iopub.status.idle": "2026-07-23T20:40:11.087000Z",
           "shell.execute_reply": "2026-07-23T20:40:11.087000Z"
-        }
+        },
+        "qubonotebooks_colab_import_id": "imports"
       },
       "outputs": [],
       "source": [
+        "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
         "Base.invokelatest(\n",
         "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-        "    \"11-Annealing\";\n",
-        "    suppress_logs = true,\n",
-        ");"
+        "    \"11-Annealing\",\n",
+        ");\n"
       ]
     },
     {

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -208,11 +208,17 @@
      "iopub.status.idle": "2026-07-10T22:04:28.280000Z",
      "shell.execute_reply": "2026-07-10T22:04:28.280000Z"
     },
-    "id": "T3-adk-gMniL"
+    "id": "T3-adk-gMniL",
+    "qubonotebooks_colab_import_id": "imports-karnak"
    },
    "outputs": [],
    "source": [
-    "using Karnak\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Karnak\",\n",
+    "    :(using Karnak),\n",
+    ");\n"
    ]
   },
   {
@@ -225,11 +231,17 @@
      "iopub.status.idle": "2026-07-10T22:04:28.296000Z",
      "shell.execute_reply": "2026-07-10T22:04:28.296000Z"
     },
-    "id": "TMr9jc7o3n5h"
+    "id": "TMr9jc7o3n5h",
+    "qubonotebooks_colab_import_id": "imports-linearalgebra"
    },
    "outputs": [],
    "source": [
-    "using LinearAlgebra\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"LinearAlgebra\",\n",
+    "    :(using LinearAlgebra),\n",
+    ");\n"
    ]
   },
   {
@@ -242,11 +254,17 @@
      "iopub.status.idle": "2026-07-10T22:04:28.298000Z",
      "shell.execute_reply": "2026-07-10T22:04:28.298000Z"
     },
-    "id": "azi-mgz93n5i"
+    "id": "azi-mgz93n5i",
+    "qubonotebooks_colab_import_id": "imports-graphs"
    },
    "outputs": [],
    "source": [
-    "using Graphs\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Graphs\",\n",
+    "    :(using Graphs),\n",
+    ");\n"
    ]
   },
   {
@@ -263,11 +281,17 @@
      "shell.execute_reply": "2026-07-10T22:04:29.068000Z"
     },
     "id": "N2C3i8kA3n5k",
-    "outputId": "a634d238-4a37-4b31-cb18-4d609ebe6443"
+    "outputId": "a634d238-4a37-4b31-cb18-4d609ebe6443",
+    "qubonotebooks_colab_import_id": "imports-jump"
    },
    "outputs": [],
    "source": [
-    "using JuMP\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"JuMP\",\n",
+    "    :(using JuMP),\n",
+    ");\n"
    ]
   },
   {
@@ -284,11 +308,17 @@
      "shell.execute_reply": "2026-07-10T22:04:29.416000Z"
     },
     "id": "Tzw2eioU3n5k",
-    "outputId": "3f929879-2e80-43b7-d348-154902afd34d"
+    "outputId": "3f929879-2e80-43b7-d348-154902afd34d",
+    "qubonotebooks_colab_import_id": "imports-qubo"
    },
    "outputs": [],
    "source": [
-    "using QUBO\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"QUBO\",\n",
+    "    :(using QUBO),\n",
+    ");\n"
    ]
   },
   {
@@ -305,11 +335,17 @@
      "shell.execute_reply": "2026-07-10T22:04:30.581000Z"
     },
     "id": "FsebN2x83n5l",
-    "outputId": "b2e52570-b939-4250-b2b9-60540085d366"
+    "outputId": "b2e52570-b939-4250-b2b9-60540085d366",
+    "qubonotebooks_colab_import_id": "imports-plots"
    },
    "outputs": [],
    "source": [
-    "using Plots\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Plots\",\n",
+    "    :(using Plots),\n",
+    ");\n"
    ]
   },
   {
@@ -326,11 +362,17 @@
      "shell.execute_reply": "2026-07-10T22:04:30.636000Z"
     },
     "id": "b12ZiiHG3n5l",
-    "outputId": "ee5f24e9-763b-4545-ff46-4641a9b77f08"
+    "outputId": "ee5f24e9-763b-4545-ff46-4641a9b77f08",
+    "qubonotebooks_colab_import_id": "imports-glpk"
    },
    "outputs": [],
    "source": [
-    "using GLPK\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"GLPK\",\n",
+    "    :(using GLPK),\n",
+    ");\n"
    ]
   },
   {
@@ -347,298 +389,17 @@
      "shell.execute_reply": "2026-07-10T22:04:37.472000Z"
     },
     "id": "Ytpc1DhR3n5n",
-    "outputId": "b6332114-44a7-49ae-eace-d9a7d978b847"
+    "outputId": "b6332114-44a7-49ae-eace-d9a7d978b847",
+    "qubonotebooks_colab_import_id": "imports-dwave"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mFound dependencies: <LOCAL_JULIA_DEPOT>/packages/DWave/Gf7Yh/CondaPkg.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mFound dependencies: <JULIA_DEPOT>/packages/CondaPkg/0UqYV/CondaPkg.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mFound dependencies: <JULIA_DEPOT>/packages/PythonCall/5WGSP/CondaPkg.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mFound dependencies: <JULIA_DEPOT>/packages/PythonPlot/oS8x4/CondaPkg.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mInitialising pixi\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m<JULIA_DEPOT>/artifacts/4ae17cee0bd922f66b2c72bf2f01c22481a5ec19/bin/pixi\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90minit\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m--format pixi\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m└ \u001b[90m./notebooks_jl/.CondaPkg\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "✔ Created ./notebooks_jl/.CondaPkg/pixi.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mWrote ./notebooks_jl/.CondaPkg/pixi.toml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m[dependencies]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mopenssl = \">=3, <3.6\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mlibstdcxx = \">=3.4,<15.0\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90muv = \">=0.4\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mlibstdcxx-ng = \">=3.4,<15.0\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mmatplotlib = \">=3, >=1\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m    [dependencies.python]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m    channel = \"conda-forge\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m    build = \"*cp*\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m    version = \">=3.10,!=3.14.0,!=3.14.1,<4, >=3.11,<=3.13\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m[project]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mname = \".CondaPkg\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mplatforms = [\"linux-64\"]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mchannels = [\"conda-forge\", \"anaconda\"]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mchannel-priority = \"strict\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mdescription = \"automatically generated by CondaPkg.jl\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m[pypi-dependencies]\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90mdwave-networkx = \"==0.8.18\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m└ \u001b[90mdwave-ocean-sdk = \"==9.3.0\"\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m    CondaPkg \u001b[22m\u001b[39m\u001b[0mInstalling packages\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90m<JULIA_DEPOT>/artifacts/4ae17cee0bd922f66b2c72bf2f01c22481a5ec19/bin/pixi\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m│ \u001b[90minstall\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m\u001b[1m             \u001b[22m\u001b[39m└ \u001b[90m--manifest-path ./notebooks_jl/.CondaPkg/pixi.toml\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " WARN Encountered 1 warning while parsing the manifest:\n",
-      "  ⚠ The `project` field is deprecated. Use `workspace` instead.\n",
-      "    ╭─[./notebooks_jl/.CondaPkg/pixi.toml:13:1]\n",
-      " 12 │     \n",
-      " 13 │ ╭─▶ [project]\n",
-      " 14 │ │   name = \".CondaPkg\"\n",
-      " 15 │ │   platforms = [\"linux-64\"]\n",
-      " 16 │ │   channels = [\"conda-forge\", \"anaconda\"]\n",
-      " 17 │ │   channel-priority = \"strict\"\n",
-      " 18 │ ├─▶ description = \"automatically generated by CondaPkg.jl\"\n",
-      "    · ╰──── replace this with 'workspace'\n",
-      " 19 │     \n",
-      "    ╰────\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "✔ The default environment has been installed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "using DWave\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"DWave\",\n",
+    "    :(using DWave),\n",
+    ");\n"
    ]
   },
   {
@@ -655,11 +416,17 @@
      "shell.execute_reply": "2026-07-10T22:04:37.474000Z"
     },
     "id": "-6UXOFrGYjx8",
-    "outputId": "6fa21998-50d7-48e2-d819-332a911d2fc8"
+    "outputId": "6fa21998-50d7-48e2-d819-332a911d2fc8",
+    "qubonotebooks_colab_import_id": "imports-luxor"
    },
    "outputs": [],
    "source": [
-    "using Luxor"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Luxor\",\n",
+    "    :(using Luxor),\n",
+    ");\n"
    ]
   },
   {

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -255,6 +255,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-delimited-random"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"DelimitedFiles and Random\",\n",
+    "    :(begin\n",
+    "        using DelimitedFiles\n",
+    "        using Random\n",
+    "    end),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "metadata": {
     "execution": {
@@ -277,9 +296,6 @@
     }
    ],
    "source": [
-    "using DelimitedFiles\n",
-    "using Random\n",
-    "\n",
     "const ε_default = 0.01\n",
     "\n",
     "function shared_data_path(filename::AbstractString)\n",
@@ -327,7 +343,7 @@
     "\n",
     "function f(x; μ=μ_default, σ=σ_default, ε=ε_default)\n",
     "    return μ'x + sqrt(((1 - ε) / ε) * (σ .^ 2)' * (x .^ 2))\n",
-    "end"
+    "end\n"
    ]
   },
   {
@@ -435,15 +451,23 @@
      "iopub.status.busy": "2026-07-10T17:51:25.361000Z",
      "iopub.status.idle": "2026-07-10T17:51:25.626000Z",
      "shell.execute_reply": "2026-07-10T17:51:25.626000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-4ti2"
    },
    "outputs": [],
    "source": [
-    "import lib4ti2_jll\n",
-    "import BinaryWrappers\n",
-    "using DelimitedFiles\n",
-    "using Downloads\n",
-    "using NPZ\n"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"4ti2 dependencies\",\n",
+    "    :(begin\n",
+    "        import lib4ti2_jll\n",
+    "        import BinaryWrappers\n",
+    "        using DelimitedFiles\n",
+    "        using Downloads\n",
+    "        using NPZ\n",
+    "    end),\n",
+    ");\n"
    ]
   },
   {
@@ -1014,30 +1038,29 @@
      "iopub.status.busy": "2026-07-10T17:51:30.983000Z",
      "iopub.status.idle": "2026-07-10T17:51:35.381000Z",
      "shell.execute_reply": "2026-07-10T17:51:35.380000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-jump-dwave"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "true"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "using JuMP, LinearAlgebra\n",
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"JuMP and LinearAlgebra\",\n",
+    "    :(using JuMP, LinearAlgebra),\n",
+    ");\n",
     "\n",
     "const HAS_DWAVE = try\n",
-    "    @eval using DWave\n",
+    "    Base.invokelatest(\n",
+    "        QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "        \"DWave\",\n",
+    "        :(using DWave),\n",
+    "    );\n",
     "    true\n",
     "catch e\n",
     "    @warn \"DWave.jl not available. Feasible-start QUBO sampling will use bundled starts instead.\" exception=(e, catch_backtrace())\n",
     "    false\n",
-    "end"
+    "end;\n"
    ]
   },
   {
@@ -1210,11 +1233,17 @@
      "iopub.status.busy": "2026-07-10T17:51:44.943000Z",
      "iopub.status.idle": "2026-07-10T17:51:46.939000Z",
      "shell.execute_reply": "2026-07-10T17:51:46.939000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-plots"
    },
    "outputs": [],
    "source": [
-    "using Measures, Random, Plots, StatsBase, StatsPlots"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"plotting and statistics packages\",\n",
+    "    :(using Measures, Random, Plots, StatsBase, StatsPlots),\n",
+    ");\n"
    ]
   },
   {

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -320,11 +320,17 @@
      "iopub.status.busy": "2026-07-10T17:52:15.605000Z",
      "iopub.status.idle": "2026-07-10T17:52:15.605000Z",
      "shell.execute_reply": "2026-07-10T17:52:15.605000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-linearalgebra"
    },
    "outputs": [],
    "source": [
-    "using LinearAlgebra"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"LinearAlgebra\",\n",
+    "    :(using LinearAlgebra),\n",
+    ");\n"
    ]
   },
   {
@@ -394,15 +400,23 @@
      "iopub.status.busy": "2026-07-10T17:52:17.176000Z",
      "iopub.status.idle": "2026-07-10T17:52:22.725000Z",
      "shell.execute_reply": "2026-07-10T17:52:22.725000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-dwave-stack"
    },
    "outputs": [],
    "source": [
-    "using DWave\n",
-    "DWave.PythonCall.pyimport(\"matplotlib\") # Load conda Matplotlib before Plots/GR shared libraries.\n",
-    "using Plots\n",
-    "using JuMP\n",
-    "using QUBO"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"DWave and plotting packages\",\n",
+    "    :(begin\n",
+    "        using DWave\n",
+    "        DWave.PythonCall.pyimport(\"matplotlib\") # Load conda Matplotlib before Plots/GR shared libraries.\n",
+    "        using Plots\n",
+    "        using JuMP\n",
+    "        using QUBO\n",
+    "    end),\n",
+    ");\n"
    ]
   },
   {

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -275,13 +275,21 @@
      "iopub.status.busy": "2026-07-10T17:53:03.515000Z",
      "iopub.status.idle": "2026-07-10T17:53:05.138000Z",
      "shell.execute_reply": "2026-07-10T17:53:05.138000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-modeling"
    },
    "outputs": [],
    "source": [
-    "using LinearAlgebra\n",
-    "using JuMP\n",
-    "using QUBO"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"modeling packages\",\n",
+    "    :(begin\n",
+    "        using LinearAlgebra\n",
+    "        using JuMP\n",
+    "        using QUBO\n",
+    "    end),\n",
+    ");\n"
    ]
   },
   {
@@ -381,11 +389,17 @@
      "iopub.status.busy": "2026-07-10T17:53:06.613000Z",
      "iopub.status.idle": "2026-07-10T17:53:07.659000Z",
      "shell.execute_reply": "2026-07-10T17:53:07.659000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-plots"
    },
    "outputs": [],
    "source": [
-    "using Plots"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Plots\",\n",
+    "    :(using Plots),\n",
+    ");\n"
    ]
   },
   {
@@ -578,6 +592,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-measures-energy"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Measures\",\n",
+    "    :(using Measures),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {
     "execution": {
@@ -605,8 +635,6 @@
     }
    ],
    "source": [
-    "using Measures\n",
-    "\n",
     "# Plot 1: Energy values for all solutions\n",
     "function plot_energy_values(energies, occurrences; title=nothing)\n",
     "    # Sort by energy\n",
@@ -812,11 +840,17 @@
      "iopub.status.busy": "2026-07-10T17:53:16.455000Z",
      "iopub.status.idle": "2026-07-10T17:53:19.222000Z",
      "shell.execute_reply": "2026-07-10T17:53:19.222000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-dwave"
    },
    "outputs": [],
    "source": [
-    "import DWave"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"DWave\",\n",
+    "    :(import DWave),\n",
+    ");\n"
    ]
   },
   {
@@ -1078,6 +1112,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-measures-schedule"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Measures\",\n",
+    "    :(using Measures),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 18,
    "metadata": {
     "execution": {
@@ -1098,8 +1148,6 @@
     }
    ],
    "source": [
-    "using Measures\n",
-    "\n",
     "function plot_schedule(β₀, β₁; length = 1_000, title = \"Default Geometric temperature schedule\")\n",
     "    β = geomspace(β₀, β₁; length=length)\n",
     "\n",
@@ -1124,7 +1172,7 @@
     "    return plt\n",
     "end\n",
     "\n",
-    "plot_schedule(β₀, β₁)"
+    "plot_schedule(β₀, β₁)\n"
    ]
   },
   {
@@ -1491,11 +1539,17 @@
      "iopub.status.busy": "2026-07-10T17:54:00.277000Z",
      "iopub.status.idle": "2026-07-10T17:54:00.277000Z",
      "shell.execute_reply": "2026-07-10T17:54:00.277000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-random"
    },
    "outputs": [],
    "source": [
-    "using Random"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Random\",\n",
+    "    :(using Random),\n",
+    ");\n"
    ]
   },
   {
@@ -1606,11 +1660,17 @@
      "iopub.status.busy": "2026-07-10T17:54:02.140000Z",
      "iopub.status.idle": "2026-07-10T17:54:02.141000Z",
      "shell.execute_reply": "2026-07-10T17:54:02.141000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-statistics"
    },
    "outputs": [],
    "source": [
-    "using Statistics"
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Statistics\",\n",
+    "    :(using Statistics),\n",
+    ");\n"
    ]
   },
   {
@@ -1921,6 +1981,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-zipfile"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"ZipFile\",\n",
+    "    :(import ZipFile),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 34,
    "metadata": {
     "execution": {
@@ -1940,8 +2016,6 @@
     }
    ],
    "source": [
-    "import ZipFile\n",
-    "\n",
     "zip_name = joinpath(pickle_path, \"results.zip\")\n",
     "bundled_zip = joinpath(@__DIR__, \"results.zip\")\n",
     "\n",
@@ -1978,7 +2052,7 @@
     "    end\n",
     "\n",
     "    @info(\"Results zip file has been extracted to '$pickle_path'\")\n",
-    "end"
+    "end\n"
    ]
   },
   {
@@ -2101,6 +2175,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-analysis"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"analysis packages\",\n",
+    "    :(begin\n",
+    "        using Statistics\n",
+    "        using JSON\n",
+    "        using StatsBase\n",
+    "    end),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 37,
    "metadata": {
     "execution": {
@@ -2113,10 +2207,6 @@
    },
    "outputs": [],
    "source": [
-    "using Statistics\n",
-    "using JSON\n",
-    "using StatsBase\n",
-    "\n",
     "success_probability = 0.99\n",
     "success_threshold_percent = 5.0\n",
     "benchmark_instance = 42\n",
@@ -2526,6 +2616,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-runtime-plots"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Plots\",\n",
+    "    :(using Plots),\n",
+    ");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 40,
    "metadata": {
     "execution": {
@@ -2537,8 +2643,6 @@
    },
    "outputs": [],
    "source": [
-    "using Plots\n",
-    "\n",
     "# 1. Create the two plot objects (ax1 and ax2)\n",
     "p1 = plot()\n",
     "schedules_to_plot = [primary_schedule]\n",
@@ -2586,7 +2690,26 @@
     ")\n",
     "\n",
     "# 6. Display the final combined plot\n",
-    "display(p_final)"
+    "display(p_final)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports-ttt-plots"
+   },
+   "outputs": [],
+   "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"Plots and Measures\",\n",
+    "    :(begin\n",
+    "        using Plots\n",
+    "        using Measures\n",
+    "    end),\n",
+    ");\n"
    ]
   },
   {
@@ -2602,9 +2725,6 @@
    },
    "outputs": [],
    "source": [
-    "using Plots\n",
-    "using Measures\n",
-    "\n",
     "function plot_ttt_grid_adapted(sweeps, schedules, results; \n",
     "                        main_boot, \n",
     "                        inset_boot, \n",
@@ -2737,7 +2857,7 @@
     "    inset_hline_boot = default_sweeps\n",
     ")\n",
     "\n",
-    "display(p_final)"
+    "display(p_final)\n"
    ]
   },
   {
@@ -2800,11 +2920,18 @@
      "iopub.status.busy": "2026-07-10T17:54:08.868000Z",
      "iopub.status.idle": "2026-07-10T17:54:08.869000Z",
      "shell.execute_reply": "2026-07-10T17:54:08.869000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports-statsbase"
    },
    "outputs": [],
    "source": [
-    "using StatsBase # For the 'percentile' function"
+    "# For the percentile function\n",
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
+    "Base.invokelatest(\n",
+    "    QUBONotebooksBootstrap.load_notebook_packages!,\n",
+    "    \"StatsBase\",\n",
+    "    :(using StatsBase),\n",
+    ");\n"
    ]
   },
   {

--- a/notebooks_jl/6-QCi.ipynb
+++ b/notebooks_jl/6-QCi.ipynb
@@ -186,20 +186,19 @@
      "iopub.status.busy": "2026-07-26T05:05:48.823000Z",
      "iopub.status.idle": "2026-07-26T05:05:57.652000Z",
      "shell.execute_reply": "2026-07-26T05:05:57.652000Z"
-    }
+    },
+    "qubonotebooks_colab_import_id": "imports"
    },
    "outputs": [],
    "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
     "Base.invokelatest(\n",
     "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-    "    \"6-QCi\";\n",
-    "    suppress_logs = true,\n",
+    "    \"6-QCi\",\n",
     ");\n",
     "\n",
-    "import MathOptInterface as MOI\n",
-    "\n",
     "@assert QCIOpt.qci_default_token() === nothing\n",
-    "println(\"Loaded JuMP and QCIOpt without configuring cloud credentials.\")"
+    "println(\"Loaded JuMP and QCIOpt without configuring cloud credentials.\")\n"
    ]
   },
   {

--- a/notebooks_jl/7-CanonicalProblems.ipynb
+++ b/notebooks_jl/7-CanonicalProblems.ipynb
@@ -146,16 +146,18 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "imports",
-   "metadata": {},
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports"
+   },
    "outputs": [],
    "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
     "Base.invokelatest(\n",
     "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-    "    \"7-CanonicalProblems\";\n",
-    "    suppress_logs = true,\n",
+    "    \"7-CanonicalProblems\",\n",
     ");\n",
     "\n",
-    "Plots.default(; size = (640, 420), legend = false)"
+    "Plots.default(; size = (640, 420), legend = false)\n"
    ]
   },
   {

--- a/notebooks_jl/8-OrderPartitioning.ipynb
+++ b/notebooks_jl/8-OrderPartitioning.ipynb
@@ -151,14 +151,16 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "imports",
-   "metadata": {},
+   "metadata": {
+    "qubonotebooks_colab_import_id": "imports"
+   },
    "outputs": [],
    "source": [
+    "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
     "Base.invokelatest(\n",
     "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-    "    \"8-OrderPartitioning\";\n",
-    "    suppress_logs = true,\n",
-    ");"
+    "    \"8-OrderPartitioning\",\n",
+    ");\n"
    ]
   },
   {

--- a/notebooks_jl/9-CancerGenomics.ipynb
+++ b/notebooks_jl/9-CancerGenomics.ipynb
@@ -153,13 +153,15 @@
       "cell_type": "code",
       "execution_count": 3,
       "id": "imports",
-      "metadata": {},
+      "metadata": {
+        "qubonotebooks_colab_import_id": "imports"
+      },
       "outputs": [],
       "source": [
+        "# QUBONOTEBOOKS_COLAB_IMPORT_CELL\n",
         "Base.invokelatest(\n",
         "    QUBONotebooksBootstrap.warm_notebook_packages!,\n",
-        "    \"9-CancerGenomics\";\n",
-        "    suppress_logs = true,\n",
+        "    \"9-CancerGenomics\",\n",
         ");\n"
       ]
     },
@@ -255,7 +257,7 @@
         "        for j in (i + 1):n_genes\n",
         "            overlap = sum(B[:, i] .* B[:, j])\n",
         "            A[i, j] = overlap\n",
-    "            A[j, i] = overlap\n",
+        "            A[j, i] = overlap\n",
         "        end\n",
         "    end\n",
         "\n",

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -570,14 +570,14 @@ function load_notebook_packages!(
 end
 
 """
-    warm_notebook_packages!(project_key; suppress_logs=detect_colab())
+    warm_notebook_packages!(project_key; suppress_logs=true)
 
 Load the complete declared package set for a notebook. This remains an explicit
 opt-in warm-up; normal notebook execution loads packages from marked import cells.
 """
 function warm_notebook_packages!(
     project_key::AbstractString;
-    suppress_logs::Bool = detect_colab(),
+    suppress_logs::Bool = true,
 )
     import_expr = notebook_import_expr(project_key)
     import_expr === nothing && return false

--- a/scripts/notebook_bootstrap.jl
+++ b/scripts/notebook_bootstrap.jl
@@ -46,7 +46,10 @@ const NOTEBOOK_IMPORTS = Dict(
     "3-GAMA" => :(using BinaryWrappers, DelimitedFiles, Downloads, NPZ, JuMP, DWave, LinearAlgebra, Measures, Random, Plots, StatsBase, StatsPlots, lib4ti2_jll),
     "4-DWave" => :(using LinearAlgebra, Plots, JuMP, QUBO, DWave, Graphs),
     "5-Benchmarking" => :(using JuMP, QUBO, LinearAlgebra, Plots, Measures, DWave, Random, Statistics, ZipFile, JSON, StatsBase),
-    "6-QCi" => :(using JuMP, QCIOpt),
+    "6-QCi" => :(begin
+        using JuMP, QCIOpt
+        import MathOptInterface as MOI
+    end),
     "7-CanonicalProblems" => :(using JuMP, Plots, QUBO),
     "8-OrderPartitioning" => :(using JuMP, Printf, QUBO),
     "9-CancerGenomics" => :(using DWave, JSON, JuMP, LinearAlgebra, Logging, Printf, QUBO),
@@ -532,19 +535,24 @@ function instantiate_project!(
     return refreshed_for_current_julia
 end
 
-function warm_notebook_packages!(
-    project_key::AbstractString;
-    suppress_logs::Bool = true,
-)
-    import_expr = notebook_import_expr(project_key)
-    import_expr === nothing && return false
+"""
+    load_notebook_packages!(label, import_expr; project_key=nothing, suppress_logs=detect_colab())
 
+Evaluate one notebook import expression in `Main`. Colab import transcripts are
+suppressed when requested, while exceptions continue to propagate to the cell.
+"""
+function load_notebook_packages!(
+    label::AbstractString,
+    import_expr::Expr;
+    project_key::Union{Nothing,AbstractString} = nothing,
+    suppress_logs::Bool = detect_colab(),
+)
     function load_packages()
-        if project_key in CREDENTIAL_FREE_DWAVE_NOTEBOOKS
+        if project_key !== nothing && project_key in CREDENTIAL_FREE_DWAVE_NOTEBOOKS
             return withenv("DWAVE_API_TOKEN" => nothing) do
                 Core.eval(Main, import_expr)
             end
-        elseif project_key in CREDENTIAL_FREE_QCI_NOTEBOOKS
+        elseif project_key !== nothing && project_key in CREDENTIAL_FREE_QCI_NOTEBOOKS
             return withenv("QCI_TOKEN" => nothing) do
                 Core.eval(Main, import_expr)
             end
@@ -552,13 +560,33 @@ function warm_notebook_packages!(
         return Core.eval(Main, import_expr)
     end
 
-    log_step("Loading notebook packages")
+    log_step("Loading $label")
     if suppress_logs
         with_suppressed_output(load_packages)
     else
         load_packages()
     end
     return true
+end
+
+"""
+    warm_notebook_packages!(project_key; suppress_logs=detect_colab())
+
+Load the complete declared package set for a notebook. This remains an explicit
+opt-in warm-up; normal notebook execution loads packages from marked import cells.
+"""
+function warm_notebook_packages!(
+    project_key::AbstractString;
+    suppress_logs::Bool = detect_colab(),
+)
+    import_expr = notebook_import_expr(project_key)
+    import_expr === nothing && return false
+    return load_notebook_packages!(
+        "notebook packages",
+        import_expr;
+        project_key = project_key,
+        suppress_logs = suppress_logs,
+    )
 end
 
 function bootstrap_notebook(

--- a/scripts/verify_colab_bootstrap.py
+++ b/scripts/verify_colab_bootstrap.py
@@ -24,6 +24,11 @@ NOTEBOOK_PATHS = tuple(
 SELECTED_NOTEBOOKS_ENV = "QUBONOTEBOOKS_COLAB_NOTEBOOKS"
 BOOTSTRAP_MARKER = "function load_qubonotebooks_bootstrap()"
 ACTIVATION_MARKER = "Pkg.activate(JULIA_PROJECT_DIR"
+IMPORT_CELL_MARKER = "QUBONOTEBOOKS_COLAB_IMPORT_CELL"
+IMPORT_CELL_METADATA_KEY = "qubonotebooks_colab_import_id"
+PACKAGE_IMPORT_PATTERN = re.compile(
+    r"(?m)^\s*(?:@eval\s+)?(?:using|import)\s+[A-Za-z]"
+)
 KERNEL_NAME = "qubonotebooks-colab-smoke"
 IJULIA_PROJECT = """\
 [deps]
@@ -43,6 +48,10 @@ EXECUTION_FORBIDDEN_OUTPUT = (
     (
         "CondaPkg environment setup",
         re.compile(r"(?i)(?:CondaPkg|micromamba|\bpixi\b|/\.CondaPkg)"),
+    ),
+    (
+        "package precompilation output",
+        re.compile(r"(?im)^\s*(?:\[ Info:\s*)?Precompiling\b"),
     ),
 )
 FORBIDDEN_OUTPUT = (
@@ -122,71 +131,135 @@ def text_value(value: object) -> str:
     return str(value)
 
 
+def marked_code_cell(
+    repo_root: Path,
+    notebook: Path,
+    *,
+    marker: str,
+    description: str,
+    smoke_id: str,
+) -> dict[str, str]:
+    notebook_path = repo_root / notebook
+    data = json.loads(notebook_path.read_text())
+    matches = [
+        cell
+        for cell in data["cells"]
+        if cell.get("cell_type") == "code"
+        and marker in text_value(cell.get("source"))
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one {description} cell in {notebook_path}, "
+            f"found {len(matches)}."
+        )
+    return {"id": smoke_id, "source": text_value(matches[0].get("source"))}
+
+
 def bootstrap_cell_source(
     repo_root: Path,
     notebook: Path = NOTEBOOK_PATH,
 ) -> str:
-    notebook_path = repo_root / notebook
-    notebook = json.loads(notebook_path.read_text())
-    matches = [
-        text_value(cell.get("source"))
-        for cell in notebook["cells"]
-        if cell.get("cell_type") == "code"
-        and BOOTSTRAP_MARKER in text_value(cell.get("source"))
-    ]
-    if len(matches) != 1:
-        raise ValueError(
-            f"Expected exactly one bootstrap cell in {notebook_path}, found {len(matches)}."
-        )
-    return matches[0]
+    return marked_code_cell(
+        repo_root,
+        notebook,
+        marker=BOOTSTRAP_MARKER,
+        description="bootstrap",
+        smoke_id="bootstrap",
+    )["source"]
 
 
 def activation_cell_source(repo_root: Path, notebook: Path) -> str:
+    source = marked_code_cell(
+        repo_root,
+        notebook,
+        marker=ACTIVATION_MARKER,
+        description="activation",
+        smoke_id="activate",
+    )["source"]
+    if "Pkg.instantiate" not in source:
+        raise ValueError(
+            f"Activation cell in {repo_root / notebook} does not instantiate "
+            "the notebook environment."
+        )
+    return source
+
+
+def notebook_import_cells(repo_root: Path, notebook: Path) -> list[dict]:
     notebook_path = repo_root / notebook
     data = json.loads(notebook_path.read_text())
-    matches = [
-        text_value(cell.get("source"))
+    import_cells = [
+        cell
         for cell in data["cells"]
         if cell.get("cell_type") == "code"
-        and ACTIVATION_MARKER in text_value(cell.get("source"))
-        and "Pkg.instantiate" in text_value(cell.get("source"))
-    ]
-    if len(matches) != 1:
-        raise ValueError(
-            f"Expected exactly one activation cell in {notebook_path}, "
-            f"found {len(matches)}."
+        and (
+            IMPORT_CELL_MARKER in text_value(cell.get("source"))
+            or cell.get("metadata", {}).get(IMPORT_CELL_METADATA_KEY)
         )
-    return matches[0]
-
-
-def smoke_cell_sources(repo_root: Path, notebook: Path) -> list[str]:
-    sources = [
-        bootstrap_cell_source(repo_root, notebook),
-        activation_cell_source(repo_root, notebook),
     ]
-    data = json.loads((repo_root / notebook).read_text())
-    import_sources = [
-        text_value(cell.get("source"))
-        for cell in data["cells"]
-        if cell.get("cell_type") == "code" and cell.get("id") == "imports"
+    if not import_cells:
+        raise ValueError(f"Expected at least one marked import cell in {notebook_path}.")
+
+    import_ids = [
+        cell.get("metadata", {}).get(IMPORT_CELL_METADATA_KEY)
+        for cell in import_cells
     ]
-    if len(import_sources) > 1:
+    if any(not cell_id for cell_id in import_ids):
         raise ValueError(
-            f"Expected at most one 'imports' cell in {repo_root / notebook}, "
-            f"found {len(import_sources)}."
+            f"Every marked import cell in {notebook_path} must have "
+            f"'{IMPORT_CELL_METADATA_KEY}' metadata."
         )
-    if import_sources:
-        return [*sources, *import_sources]
+    if len(import_ids) != len(set(import_ids)):
+        raise ValueError(f"Marked import cell ids are not unique in {notebook_path}.")
+    if any(not str(cell_id).startswith("imports") for cell_id in import_ids):
+        raise ValueError(
+            f"Marked import cell ids in {notebook_path} must start with 'imports'."
+        )
+    missing_source_markers = [
+        str(cell_id)
+        for cell_id, cell in zip(import_ids, import_cells)
+        if IMPORT_CELL_MARKER not in text_value(cell.get("source"))
+    ]
+    if missing_source_markers:
+        raise ValueError(
+            f"Marked import cell(s) in {notebook_path} are missing the source marker: "
+            + ", ".join(missing_source_markers)
+        )
 
-    project_key = notebook.stem
-    warmup_source = (
-        "Base.invokelatest(\n"
-        "    QUBONotebooksBootstrap.warm_notebook_packages!,\n"
-        f'    "{project_key}";\n'
-        "    suppress_logs = true,\n"
-        ");\n"
-    )
-    return [*sources, warmup_source]
+    unmarked_imports = []
+    for index, cell in enumerate(data["cells"], start=1):
+        if cell.get("cell_type") != "code":
+            continue
+        source = text_value(cell.get("source"))
+        if BOOTSTRAP_MARKER in source or ACTIVATION_MARKER in source:
+            continue
+        import_id = cell.get("metadata", {}).get(IMPORT_CELL_METADATA_KEY)
+        if PACKAGE_IMPORT_PATTERN.search(source) and not import_id:
+            unmarked_imports.append(str(cell.get("id") or f"cell-{index}"))
+    if unmarked_imports:
+        raise ValueError(
+            f"Found unmarked package import cell(s) in {notebook_path}: "
+            + ", ".join(unmarked_imports)
+        )
+    return import_cells
+
+
+def smoke_cells(repo_root: Path, notebook: Path) -> list[dict[str, str]]:
+    bootstrap = {
+        "id": "bootstrap",
+        "source": bootstrap_cell_source(repo_root, notebook),
+    }
+    activation = {
+        "id": "activate",
+        "source": activation_cell_source(repo_root, notebook),
+    }
+    imports = [
+        {
+            "id": str(cell["metadata"][IMPORT_CELL_METADATA_KEY]),
+            "source": text_value(cell.get("source")),
+        }
+        for cell in notebook_import_cells(repo_root, notebook)
+    ]
+    return [bootstrap, activation, *imports]
 
 
 def output_text(outputs: list[dict]) -> str:
@@ -313,18 +386,18 @@ def write_colab_fixture(repo_root: Path, workspace: Path) -> None:
     )
 
 
-def write_smoke_notebook(sources: list[str], path: Path) -> None:
+def write_smoke_notebook(cells: list[dict[str, str]], path: Path) -> None:
     notebook = {
         "cells": [
             {
                 "cell_type": "code",
                 "execution_count": None,
-                "id": f"smoke-{index}",
+                "id": cell["id"],
                 "metadata": {},
                 "outputs": [],
-                "source": source.splitlines(keepends=True),
+                "source": cell["source"].splitlines(keepends=True),
             }
-            for index, source in enumerate(sources, start=1)
+            for cell in cells
         ],
         "metadata": {
             "kernelspec": {
@@ -493,7 +566,7 @@ def main() -> int:
             smoke_notebook = workspace / smoke_name
             executed_notebook = output_dir / smoke_name
             write_smoke_notebook(
-                smoke_cell_sources(repo_root, notebook_path),
+                smoke_cells(repo_root, notebook_path),
                 smoke_notebook,
             )
             run(

--- a/scripts/verify_hosted_colab.py
+++ b/scripts/verify_hosted_colab.py
@@ -154,7 +154,7 @@ def execute_native_smoke(
     smoke_notebook = output_dir / smoke_name
     executed_notebook = output_dir / f"executed-{smoke_name}"
     smoke.write_smoke_notebook(
-        smoke.smoke_cell_sources(repo_root, notebook_path),
+        smoke.smoke_cells(repo_root, notebook_path),
         smoke_notebook,
     )
 
@@ -353,12 +353,38 @@ def colab_run_command(
     ]
 
 
+def colab_run_commands(
+    *,
+    script_path: Path,
+    auth: str,
+    timeout: float,
+    repo_ref: str,
+    repo_url: str,
+    notebook_keys: tuple[str, ...],
+) -> list[list[str]]:
+    """Build one auto-released Colab invocation per notebook key."""
+    return [
+        colab_run_command(
+            script_path=script_path,
+            auth=auth,
+            timeout=timeout,
+            repo_ref=repo_ref,
+            repo_url=repo_url,
+            notebooks=notebook_key,
+        )
+        for notebook_key in notebook_keys
+    ]
+
+
 def local_main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--notebooks",
-        default=os.environ.get(SELECTED_NOTEBOOKS_ENV, "11-Annealing"),
-        help="Comma- or space-separated Julia notebook keys (default: 11-Annealing).",
+        default=os.environ.get(SELECTED_NOTEBOOKS_ENV, ""),
+        help=(
+            "Comma- or space-separated Julia notebook keys "
+            "(default: every Julia notebook)."
+        ),
     )
     parser.add_argument("--ref", default=os.environ.get(REPO_REF_ENV) or git_head())
     parser.add_argument(
@@ -376,17 +402,24 @@ def local_main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    run(
-        colab_run_command(
-            script_path=Path(__file__).resolve(),
-            auth=args.auth,
-            timeout=args.timeout,
-            repo_ref=args.ref,
-            repo_url=args.repo_url,
-            notebooks=args.notebooks,
-        ),
-        cwd=REPO_ROOT,
+    smoke = load_smoke_module(REPO_ROOT)
+    notebook_keys = tuple(
+        notebook_path.stem
+        for notebook_path in smoke.selected_notebook_paths(args.notebooks)
     )
+    commands = colab_run_commands(
+        script_path=Path(__file__).resolve(),
+        auth=args.auth,
+        timeout=args.timeout,
+        repo_ref=args.ref,
+        repo_url=args.repo_url,
+        notebook_keys=notebook_keys,
+    )
+    for command in commands:
+        run(
+            command,
+            cwd=REPO_ROOT,
+        )
     return 0
 
 

--- a/test/issue_90_colab_bootstrap_output.jl
+++ b/test/issue_90_colab_bootstrap_output.jl
@@ -94,6 +94,41 @@ using Test
         suppress_logs = true,
     )
 
+    warmup_test_key = "__quiet-default-test__"
+    @test !haskey(QUBONotebooksBootstrap.NOTEBOOK_IMPORTS, warmup_test_key)
+    try
+        QUBONotebooksBootstrap.NOTEBOOK_IMPORTS[warmup_test_key] = :(begin
+            println(stdout, "hidden default warm-up stdout")
+            println(stderr, "hidden default warm-up stderr")
+            @info "hidden default warm-up log"
+        end)
+        mktemp() do _, stdout_io
+            mktemp() do _, stderr_io
+                loaded = redirect_stdout(stdout_io) do
+                    redirect_stderr(stderr_io) do
+                        Base.invokelatest(
+                            QUBONotebooksBootstrap.warm_notebook_packages!,
+                            warmup_test_key,
+                        )
+                    end
+                end
+                flush(stdout_io)
+                flush(stderr_io)
+                seekstart(stdout_io)
+                seekstart(stderr_io)
+                captured_stdout = read(stdout_io, String)
+                captured_stderr = read(stderr_io, String)
+
+                @test loaded === true
+                @test occursin("Loading notebook packages", captured_stdout)
+                @test !occursin("hidden default warm-up", captured_stdout)
+                @test isempty(captured_stderr)
+            end
+        end
+    finally
+        delete!(QUBONotebooksBootstrap.NOTEBOOK_IMPORTS, warmup_test_key)
+    end
+
     for operation in (
         "Pkg.activate(project_dir; io = pkg_io)",
         "Pkg.update(; io = pkg_io)",

--- a/test/issue_90_colab_bootstrap_output.jl
+++ b/test/issue_90_colab_bootstrap_output.jl
@@ -56,6 +56,44 @@ using Test
         end
     end
 
+    mktemp() do _, stdout_io
+        mktemp() do _, stderr_io
+            loaded = redirect_stdout(stdout_io) do
+                redirect_stderr(stderr_io) do
+                    Base.invokelatest(
+                        QUBONotebooksBootstrap.load_notebook_packages!,
+                        "test packages",
+                        :(begin
+                            println(stdout, "hidden import stdout")
+                            println(stderr, "hidden import stderr")
+                            @info "hidden import log"
+                            17
+                        end);
+                        suppress_logs = true,
+                    )
+                end
+            end
+            flush(stdout_io)
+            flush(stderr_io)
+            seekstart(stdout_io)
+            seekstart(stderr_io)
+            captured_stdout = read(stdout_io, String)
+            captured_stderr = read(stderr_io, String)
+
+            @test loaded === true
+            @test occursin("Loading test packages", captured_stdout)
+            @test !occursin("hidden import", captured_stdout)
+            @test isempty(captured_stderr)
+        end
+    end
+
+    @test_throws ErrorException Base.invokelatest(
+        QUBONotebooksBootstrap.load_notebook_packages!,
+        "failing test package",
+        :(error("import failure must propagate"));
+        suppress_logs = true,
+    )
+
     for operation in (
         "Pkg.activate(project_dir; io = pkg_io)",
         "Pkg.update(; io = pkg_io)",

--- a/tests/test_qci_julia_notebook.py
+++ b/tests/test_qci_julia_notebook.py
@@ -233,7 +233,9 @@ class QCIJuliaNotebookTests(unittest.TestCase):
         self.assertNotIn("qci", pyproject["dependency-groups"])
         self.assertNotIn("qiskit", pyproject["dependency-groups"])
         self.assertNotIn("conflicts", pyproject["tool"]["uv"])
-        self.assertIn('"6-QCi" => :(using JuMP, QCIOpt)', bootstrap)
+        self.assertIn('"6-QCi" => :(begin', bootstrap)
+        self.assertIn("using JuMP, QCIOpt", bootstrap)
+        self.assertIn("import MathOptInterface as MOI", bootstrap)
         self.assertNotIn("qci-client", bootstrap)
         self.assertIn(
             "env -u JULIA_CONDAPKG_BACKEND -u JULIA_PYTHONCALL_EXE",

--- a/tests/test_verify_colab_bootstrap.py
+++ b/tests/test_verify_colab_bootstrap.py
@@ -4,6 +4,7 @@ import importlib.util
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -55,6 +56,7 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
         )[0]
 
         self.assertIn("--with pip", target)
+        self.assertIn("--with matplotlib", target)
         self.assertNotIn("--with dwave-ocean-sdk", target)
 
     def test_hosted_target_uses_a_fresh_auto_released_colab_vm(self) -> None:
@@ -72,6 +74,21 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
         self.assertNotIn("--keep", command)
         self.assertIn("QUBONOTEBOOKS_HOSTED_COLAB_RUNNER=checkout", command)
         self.assertIn(f"QUBONOTEBOOKS_REPO_REF={'a' * 40}", command)
+
+    def test_hosted_all_notebook_plan_uses_one_fresh_vm_per_notebook(self) -> None:
+        commands = verify_hosted_colab.colab_run_commands(
+            script_path=HOSTED_MODULE_PATH,
+            auth="oauth2",
+            timeout=3600,
+            repo_ref="a" * 40,
+            repo_url="https://github.com/JuliaQUBO/QUBONotebooks.git",
+            notebook_keys=("1-MathProg", "2-QUBO"),
+        )
+
+        self.assertEqual(2, len(commands))
+        self.assertIn("QUBONOTEBOOKS_COLAB_NOTEBOOKS=1-MathProg", commands[0])
+        self.assertIn("QUBONOTEBOOKS_COLAB_NOTEBOOKS=2-QUBO", commands[1])
+        self.assertTrue(all("--keep" not in command for command in commands))
 
     def test_hosted_runner_loads_when_colab_does_not_define_file(self) -> None:
         source = HOSTED_MODULE_PATH.read_text()
@@ -119,13 +136,13 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
 
     def test_notebook_11_keeps_dwave_loading_out_of_bootstrap(self) -> None:
         notebook_path = Path("notebooks_jl/11-Annealing.ipynb")
-        sources = verify_colab_bootstrap.smoke_cell_sources(
+        cells = verify_colab_bootstrap.smoke_cells(
             REPO_ROOT,
             notebook_path,
         )
 
-        self.assertIn("warm_notebook_packages!", sources[2])
-        self.assertIn('"11-Annealing"', sources[2])
+        self.assertIn("warm_notebook_packages!", cells[2]["source"])
+        self.assertIn('"11-Annealing"', cells[2]["source"])
 
     def test_smoke_inventory_covers_every_julia_notebook(self) -> None:
         expected_paths = tuple(
@@ -166,37 +183,172 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
         self.assertTrue(source.rstrip().endswith("IN_COLAB = BOOTSTRAP.in_colab;"))
 
     def test_extracts_bootstrap_activation_and_import_cells(self) -> None:
+        expected_import_ids = {
+            "1-MathProg": (
+                "imports-plots",
+                "imports-jump",
+                "imports-glpk",
+                "imports-cbc",
+                "imports-ipopt",
+                "imports-specialfunctions",
+                "imports-bonmin",
+                "imports-couenne",
+            ),
+            "2-QUBO": (
+                "imports-karnak",
+                "imports-linearalgebra",
+                "imports-graphs",
+                "imports-jump",
+                "imports-qubo",
+                "imports-plots",
+                "imports-glpk",
+                "imports-dwave",
+                "imports-luxor",
+            ),
+            "3-GAMA": (
+                "imports-delimited-random",
+                "imports-4ti2",
+                "imports-jump-dwave",
+                "imports-plots",
+            ),
+            "4-DWave": ("imports-linearalgebra", "imports-dwave-stack"),
+            "5-Benchmarking": (
+                "imports-modeling",
+                "imports-plots",
+                "imports-measures-energy",
+                "imports-dwave",
+                "imports-measures-schedule",
+                "imports-random",
+                "imports-statistics",
+                "imports-zipfile",
+                "imports-analysis",
+                "imports-runtime-plots",
+                "imports-ttt-plots",
+                "imports-statsbase",
+            ),
+            "6-QCi": ("imports",),
+            "7-CanonicalProblems": ("imports",),
+            "8-OrderPartitioning": ("imports",),
+            "9-CancerGenomics": ("imports",),
+            "10-QAOA": ("imports",),
+            "11-Annealing": ("imports",),
+        }
+
         for notebook_path in verify_colab_bootstrap.NOTEBOOK_PATHS:
             with self.subTest(notebook=notebook_path.as_posix()):
-                sources = verify_colab_bootstrap.smoke_cell_sources(
+                cells = verify_colab_bootstrap.smoke_cells(
                     REPO_ROOT,
                     notebook_path,
                 )
 
-                self.assertEqual(3, len(sources))
-                self.assertIn("bootstrap_notebook", sources[0])
-                self.assertIn("Pkg.instantiate", sources[1])
-                self.assertIn("io = devnull", sources[1])
-                self.assertIn("warm_notebook_packages!", sources[2])
-                self.assertIn(f'"{notebook_path.stem}"', sources[2])
+                self.assertEqual(
+                    ("bootstrap", "activate", *expected_import_ids[notebook_path.stem]),
+                    tuple(cell["id"] for cell in cells),
+                )
+                self.assertIn("bootstrap_notebook", cells[0]["source"])
+                self.assertIn("Pkg.instantiate", cells[1]["source"])
+                self.assertIn("io = devnull", cells[1]["source"])
+
+                notebook = verify_colab_bootstrap.json.loads(
+                    (REPO_ROOT / notebook_path).read_text()
+                )
+                for cell in cells:
+                    if cell["id"] == "bootstrap":
+                        notebook_source = verify_colab_bootstrap.bootstrap_cell_source(
+                            REPO_ROOT,
+                            notebook_path,
+                        )
+                    elif cell["id"] == "activate":
+                        notebook_source = verify_colab_bootstrap.activation_cell_source(
+                            REPO_ROOT,
+                            notebook_path,
+                        )
+                    else:
+                        notebook_source = verify_colab_bootstrap.text_value(
+                            next(
+                                notebook_cell["source"]
+                                for notebook_cell in notebook["cells"]
+                                if notebook_cell.get("metadata", {}).get(
+                                    verify_colab_bootstrap.IMPORT_CELL_METADATA_KEY
+                                )
+                                == cell["id"]
+                            )
+                        )
+                    self.assertEqual(notebook_source, cell["source"])
 
     def test_explicit_import_cells_use_the_quiet_shared_loader(self) -> None:
         for notebook_path in verify_colab_bootstrap.NOTEBOOK_PATHS:
-            data = verify_colab_bootstrap.json.loads(
-                (REPO_ROOT / notebook_path).read_text()
+            import_cells = verify_colab_bootstrap.notebook_import_cells(
+                REPO_ROOT,
+                notebook_path,
             )
-            import_cells = [
-                cell for cell in data["cells"] if cell.get("id") == "imports"
-            ]
-            if not import_cells:
-                continue
 
             with self.subTest(notebook=notebook_path.as_posix()):
-                source = verify_colab_bootstrap.text_value(import_cells[0]["source"])
-                self.assertIn("Base.invokelatest", source)
-                self.assertIn("warm_notebook_packages!", source)
-                self.assertIn(f'"{notebook_path.stem}"', source)
-                self.assertIn("suppress_logs = true", source)
+                self.assertGreaterEqual(len(import_cells), 1)
+                for cell in import_cells:
+                    source = verify_colab_bootstrap.text_value(cell["source"])
+                    self.assertIn(
+                        verify_colab_bootstrap.IMPORT_CELL_MARKER,
+                        source,
+                    )
+                    self.assertIn("Base.invokelatest", source)
+                    self.assertRegex(
+                        source,
+                        r"(?:load|warm)_notebook_packages!",
+                    )
+
+    def test_rejects_an_unmarked_real_import_cell(self) -> None:
+        notebook_path = Path("notebooks_jl/1-MathProg.ipynb")
+        notebook = verify_colab_bootstrap.json.loads(
+            (REPO_ROOT / notebook_path).read_text()
+        )
+        import_cell = next(
+            cell
+            for cell in notebook["cells"]
+            if cell.get("metadata", {}).get(
+                verify_colab_bootstrap.IMPORT_CELL_METADATA_KEY
+            )
+            == "imports-plots"
+        )
+        import_cell["source"] = ["using Plots\n"]
+        del import_cell["metadata"][
+            verify_colab_bootstrap.IMPORT_CELL_METADATA_KEY
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            destination = root / notebook_path
+            destination.parent.mkdir(parents=True)
+            destination.write_text(verify_colab_bootstrap.json.dumps(notebook))
+
+            with self.assertRaisesRegex(ValueError, "unmarked package import"):
+                verify_colab_bootstrap.notebook_import_cells(root, notebook_path)
+
+    def test_rejects_an_activation_cell_without_instantiation(self) -> None:
+        notebook_path = Path("notebooks_jl/1-MathProg.ipynb")
+        notebook = verify_colab_bootstrap.json.loads(
+            (REPO_ROOT / notebook_path).read_text()
+        )
+        activation_cell = next(
+            cell
+            for cell in notebook["cells"]
+            if "Pkg.activate(JULIA_PROJECT_DIR"
+            in verify_colab_bootstrap.text_value(cell.get("source"))
+        )
+        activation_cell["source"] = [
+            line
+            for line in activation_cell["source"]
+            if "Pkg.instantiate" not in line
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            destination = root / notebook_path
+            destination.parent.mkdir(parents=True)
+            destination.write_text(verify_colab_bootstrap.json.dumps(notebook))
+
+            with self.assertRaisesRegex(ValueError, "does not instantiate"):
+                verify_colab_bootstrap.activation_cell_source(root, notebook_path)
 
     def test_accepts_only_concise_bootstrap_output(self) -> None:
         rendered = verify_colab_bootstrap.validate_bootstrap_outputs(clean_outputs())
@@ -226,6 +378,21 @@ class ColabBootstrapSmokeTests(unittest.TestCase):
         ]
 
         with self.assertRaisesRegex(AssertionError, r"cell 2 \(imports\)"):
+            verify_colab_bootstrap.validate_notebook_execution(cells)
+
+    def test_notebook_validation_rejects_import_precompilation_output(self) -> None:
+        cells = [
+            {"id": "bootstrap", "outputs": clean_outputs()},
+            {
+                "id": "imports-plots",
+                "outputs": [stream("[ Info: Precompiling Plots [91a5bcdd]\n")],
+            },
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"cell 2 \(imports-plots\): package precompilation output",
+        ):
             verify_colab_bootstrap.validate_notebook_execution(cells)
 
     def test_rejects_execute_results_including_trailing_true(self) -> None:


### PR DESCRIPTION
Closes #116

## Summary

- mark every real Julia import cell in notebooks 1–11 and route imports through a shared Colab-aware loader
- execute the exact marked cells in notebook order instead of substituting a synthetic aggregate warm-up
- run hosted all-notebook verification in one fresh, auto-released Colab VM per notebook

## Root cause

The smoke verifier only selected a cell whose notebook `id` was exactly `imports`. Notebooks 1–5 have progressive, mostly un-IDed import cells, so the verifier silently replaced those user-facing cells with one output-suppressed `warm_notebook_packages!` call. That false-negative path never executed the Plots or JuMP cells where the reported output appeared.

## Implementation

- Add `load_notebook_packages!`, which suppresses stdout, stderr, and Julia logging in Colab while preserving thrown import errors.
- Give every import cell stable `qubonotebooks_colab_import_id` metadata plus a source marker.
- Preserve progressive lesson boundaries; split only mixed import/computation cells where exact import-only smoke execution requires it.
- Reject missing, duplicate, reordered, or unmarked imports and reject `Precompiling`, failed-task, and CondaPkg output per cell.
- Keep default bootstrap loading deferred; explicit warm-up remains opt-in.

## Verification

- `uv run --cache-dir .uv-cache --locked --group docs python -m unittest discover -s tests` — 196 passed
- `julia +1.12 --project=test test/runtests.jl` — passed
- `make check-notebook-output-hygiene` — passed
- nbformat validation — all 11 notebooks passed
- `make verify-colab-bootstrap-output JULIA='julia +1.12' UV_CACHE_DIR=.uv-cache` — exact bootstrap, activation, and real import cells passed for all 11 notebooks in separate kernels, with explicit rejection of precompilation/task/CondaPkg output
- native hosted Colab Notebook 1 smoke at exact final SHA `6afa3124af51324aec5a5b091e84639f35c982b2` — passed on Colab release `release-colab-external-images_20260729-060048_RC00` with Julia 1.12; bootstrap 34.1s, Plots import 209.0s, JuMP import 203.5s, total 561.3s

The regression inventory failed against the pre-fix verifier because notebooks 1–5 did not expose their real import cells. Mutation coverage also proves that an unmarked import, missing activation instantiation, leaked precompilation output, or swallowed loader exception fails verification.

## Notebook outputs

Notebook results were not broadly re-executed. This change removes only the stale 39-entry CondaPkg transcript from Notebook 2's DWave import cell and the stale rendered `true` from Notebook 3's optional DWave import cell; other saved outputs are unchanged.

## Risk

The exact-head native Colab run covered the reported Notebook 1 failure on a genuinely cold hosted Julia kernel. The hosted runner can exercise all 11 notebooks with a fresh VM for each, but that quota-intensive full hosted matrix remains an explicit maintainer command rather than ordinary CI.
