### PR TITLE
Repoint retired vendor doc links and gate the book build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test:
 	fi
 
 build-book:
-	UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run --locked --group docs jupyter book build --html --ci
+	UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run --locked --group docs jupyter book build --html --ci --strict
 
 sysimage:
 	$(JULIA) -e 'using InteractiveUtils; versioninfo()'

--- a/myst.yml
+++ b/myst.yml
@@ -6,6 +6,19 @@ project:
     - name: Pedro Maciel Xavier
   copyright: "2026"
   github: JuliaQUBO/QUBONotebooks
+  # The build gates every merge and every Pages deployment, so it must depend
+  # only on this repository. Reaching ~190 third-party URLs made it fail on
+  # other people's uptime (observed: doi.org 403, img.shields.io ECONNRESET,
+  # transient Colab and D-Wave timeouts) even with no content change. External
+  # reachability is reported as a warning; unresolved internal links and
+  # cross-references still fail the build.
+  error_rules:
+    - id: link-resolves
+      severity: warn
+    - id: doi-link-valid
+      severity: warn
+    - id: reference-target-resolves
+      severity: error
   settings:
     output_matplotlib_strings: remove
   toc:

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-1-mathprog\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Introduction to Mathematical Programming</h1>\n",
@@ -2155,7 +2155,7 @@
    "metadata": {},
    "source": [
     "<div align=\"center\">\n",
-    "    <a href=\"#top\">🔝 Go back to the top 🔝</a>\n",
+    "    <a href=\"#top-jl-1-mathprog\">🔝 Go back to the top 🔝</a>\n",
     "</div>"
    ]
   }

--- a/notebooks_jl/10-QAOA.ipynb
+++ b/notebooks_jl/10-QAOA.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-10-qaoa\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "  <h1>Local-First QAOA with QiskitOpt.jl</h1>\n",

--- a/notebooks_jl/11-Annealing.ipynb
+++ b/notebooks_jl/11-Annealing.ipynb
@@ -5,7 +5,7 @@
       "id": "title",
       "metadata": {},
       "source": [
-        "<a name=\"top\" id=\"top\"></a>\n",
+        "<div id=\"top-jl-11-annealing\"></div>\n",
         "\n",
         "<div align=\"center\">\n",
         "  <h1>Local and Quantum Annealing with DWave.jl</h1>\n",

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -6,7 +6,7 @@
     "id": "xL18Dy7P3n5e"
    },
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-2-qubo\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>QUBO &amp; Ising Models</h1>\n",
@@ -1933,7 +1933,7 @@
     "id": "lxLoJWKI3n5o"
    },
    "source": [
-    "**Note:** This second tutorial is heavily inspired in D-Wave's Map coloring of Canada found **[here](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)**."
+    "**Note:** This second tutorial is heavily inspired in D-Wave's Map coloring of Canada found **[here](https://docs.dwavequantum.com/en/latest/quantum_research/example_mapcoloring.html)**."
    ]
   },
   {
@@ -2689,8 +2689,8 @@
     "\n",
     "**Further reading:**\n",
     "- [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl)\n",
-    "- [D-Wave Ocean concepts](https://docs.ocean.dwavesys.com/en/stable/concepts/index.html)\n",
-    "- [D-Wave map coloring example](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)\n"
+    "- [D-Wave Ocean concepts](https://docs.dwavequantum.com/en/latest/concepts/index.html)\n",
+    "- [D-Wave map coloring example](https://docs.dwavequantum.com/en/latest/quantum_research/example_mapcoloring.html)\n"
    ]
   },
   {
@@ -2779,7 +2779,7 @@
    },
    "source": [
     "<div align=\"center\">\n",
-    "    <a href=\"#top\">🔝 Go back to the top 🔝</a>\n",
+    "    <a href=\"#top-jl-2-qubo\">🔝 Go back to the top 🔝</a>\n",
     "</div>"
    ]
   }

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-3-gama\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Graver Augmentation Multiseed Algorithm\n",
@@ -1797,7 +1797,7 @@
    "metadata": {},
    "source": [
     "<div align=\"center\">\n",
-    "    <a href=\"#top\">🔝 Go back to the top 🔝</a>\n",
+    "    <a href=\"#top-jl-3-gama\">🔝 Go back to the top 🔝</a>\n",
     "</div>"
    ]
   }

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-4-dwave\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Quantum Annealing via D-Wave</h1>\n",
@@ -22,7 +22,7 @@
     "    <a href=\"https://colab.research.google.com/github/JuliaQUBO/QUBONotebooks/blob/main/notebooks_jl/4-DWave.ipynb\" target=\"_parent\">\n",
     "        <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "    </a>\n",
-    "    <a href=\"#installation\">\n",
+    "    <a href=\"#installation-jl-4-dwave\">\n",
     "        <img src=\"https://img.shields.io/badge/⚙️-Installation_Instructions-blue\" alt=\"Installation Instructions\"/>\n",
     "    </a>\n",
     "    <a href=\"https://secquoia.github.io/\">\n",
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"installation\" id=\"installation\"></a>\n",
+    "<div id=\"installation-jl-4-dwave\"></div>\n",
     "\n",
     "## Colab Instructions\n",
     "\n",
@@ -1142,8 +1142,8 @@
     "\n",
     "**Further reading:**\n",
     "- [DWave.jl](https://github.com/JuliaQUBO/DWave.jl)\n",
-    "- [D-Wave Ocean documentation](https://docs.ocean.dwavesys.com/)\n",
-    "- [D-Wave Leap documentation](https://docs.dwavesys.com/docs/latest/leap.html)\n"
+    "- [D-Wave Ocean documentation](https://docs.dwavequantum.com/en/latest/)\n",
+    "- [D-Wave Leap documentation](https://docs.dwavequantum.com/en/latest/leap_sapi/index.html)\n"
    ]
   },
   {
@@ -1217,7 +1217,7 @@
    "metadata": {},
    "source": [
     "<div align=\"center\">\n",
-    "    <a href=\"#top\">🔝 Go back to the top 🔝</a>\n",
+    "    <a href=\"#top-jl-4-dwave\">🔝 Go back to the top 🔝</a>\n",
     "</div>"
    ]
   }

--- a/notebooks_jl/5-Benchmarking.ipynb
+++ b/notebooks_jl/5-Benchmarking.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-5-benchmarking\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Benchmarking</h1>\n",
@@ -4658,7 +4658,7 @@
     "**Further reading:**\n",
     "- [Ronnow et al., Defining and detecting quantum speedup](https://doi.org/10.1126/science.1252319)\n",
     "- [StatsBase.jl documentation](https://juliastats.org/StatsBase.jl/stable/)\n",
-    "- [D-Wave Ocean benchmarking resources](https://docs.ocean.dwavesys.com/)\n"
+    "- [D-Wave Ocean benchmarking resources](https://docs.dwavequantum.com/en/latest/)\n"
    ]
   }
  ],

--- a/notebooks_jl/6-QCi.ipynb
+++ b/notebooks_jl/6-QCi.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-6-qci\"></div>\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JuliaQUBO/QUBONotebooks/blob/main/notebooks_jl/6-QCi.ipynb)\n",
     "\n",

--- a/notebooks_jl/7-CanonicalProblems.ipynb
+++ b/notebooks_jl/7-CanonicalProblems.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-7-canonicalproblems\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "  <h1>Three Canonical QUBO Starter Problems</h1>\n",

--- a/notebooks_jl/8-OrderPartitioning.ipynb
+++ b/notebooks_jl/8-OrderPartitioning.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-jl-8-orderpartitioning\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "  <h1>Order Partitioning for A/B Testing</h1>\n",

--- a/notebooks_jl/9-CancerGenomics.ipynb
+++ b/notebooks_jl/9-CancerGenomics.ipynb
@@ -5,7 +5,7 @@
       "id": "title",
       "metadata": {},
       "source": [
-        "<a name=\"top\" id=\"top\"></a>\n",
+        "<div id=\"top-jl-9-cancergenomics\"></div>\n",
         "\n",
         "<div align=\"center\">\n",
         "  <h1>Altered Cancer Pathways from Reproducible TCGA AML Aggregates</h1>\n",
@@ -1214,7 +1214,7 @@
         "3. T. J. Ley et al., *Genomic and Epigenomic Landscapes of Adult De Novo Acute Myeloid Leukemia*, New England Journal of Medicine 368 (2013), pp. 2059–2074, https://doi.org/10.1056/NEJMoa1301689.\n",
         "4. E. Cerami et al., *The cBio Cancer Genomics Portal: An Open Platform for Exploring Multidimensional Cancer Genomics Data*, Cancer Discovery 2 (2012), pp. 401–404, https://doi.org/10.1158/2159-8290.CD-12-0095; current portal: https://www.cbioportal.org/.\n",
         "5. Companion materials: https://github.com/arulrhikm/Solving-QUBOs-on-Quantum-Computers.\n",
-        "6. D-Wave Neal simulated annealing documentation: https://docs.ocean.dwavesys.com/projects/neal/en/latest/.\n",
+        "6. D-Wave Neal simulated annealing documentation: https://docs.dwavequantum.com/en/latest/ocean/api_ref_samplers/index.html.\n",
         "\n",
         "The committed artifact's exact query, retrieval time, aggregation rules, license, and checksums are recorded in notebooks_data/9-CancerGenomics_provenance.json. This notebook contains original Julia code and prose. The unlicensed companion repository is cited as context; no cells, prose, outputs, figures, or assets were copied.\n",
         "\n",

--- a/notebooks_py/1-MathProg_python.ipynb
+++ b/notebooks_py/1-MathProg_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-1-mathprog-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Introduction to Mathematical Programming</h1>\n",

--- a/notebooks_py/2-QUBO_python.ipynb
+++ b/notebooks_py/2-QUBO_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-2-qubo-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>QUBO &amp; Ising Models</h1>\n",
@@ -2254,7 +2254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** This tutorial is heavily inspired in D-Wave's Map coloring of Canada found **[here](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)**."
+    "**Note:** This tutorial is heavily inspired in D-Wave's Map coloring of Canada found **[here](https://docs.dwavequantum.com/en/latest/quantum_research/example_mapcoloring.html)**."
    ]
   },
   {
@@ -2774,9 +2774,9 @@
     "**Next steps:** Proceed to [Notebook 3: GAMA](3-GAMA_python.ipynb) to compare QUBO-style sampling with Graver-basis augmentation for structured integer programs.\n",
     "\n",
     "**Further reading:**\n",
-    "- [D-Wave Ocean concepts](https://docs.ocean.dwavesys.com/en/stable/concepts/index.html)\n",
-    "- [dimod documentation](https://docs.ocean.dwavesys.com/projects/dimod/en/stable/)\n",
-    "- [D-Wave map coloring example](https://docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html)\n"
+    "- [D-Wave Ocean concepts](https://docs.dwavequantum.com/en/latest/concepts/index.html)\n",
+    "- [dimod documentation](https://docs.dwavequantum.com/en/latest/ocean/api_ref_dimod/index.html)\n",
+    "- [D-Wave map coloring example](https://docs.dwavequantum.com/en/latest/quantum_research/example_mapcoloring.html)\n"
    ]
   }
  ],

--- a/notebooks_py/3-GAMA_python.ipynb
+++ b/notebooks_py/3-GAMA_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-3-gama-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Graver Augmentation Multiseed Algorithm</h1>\n",

--- a/notebooks_py/4-DWAVE_python.ipynb
+++ b/notebooks_py/4-DWAVE_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-4-dwave-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Quantum Annealing via D-Wave</h1>\n",
@@ -1100,9 +1100,9 @@
     "**Next steps:** Proceed to [Notebook 5: Benchmarking](5-Benchmarking_python.ipynb) to compare solver performance with time-to-solution and performance-ratio metrics.\n",
     "\n",
     "**Further reading:**\n",
-    "- [D-Wave Ocean documentation](https://docs.ocean.dwavesys.com/)\n",
-    "- [dwave-system documentation](https://docs.ocean.dwavesys.com/projects/system/en/stable/)\n",
-    "- [D-Wave Leap documentation](https://docs.dwavesys.com/docs/latest/leap.html)\n"
+    "- [D-Wave Ocean documentation](https://docs.dwavequantum.com/en/latest/)\n",
+    "- [dwave-system documentation](https://docs.dwavequantum.com/en/latest/ocean/api_ref_system/index.html)\n",
+    "- [D-Wave Leap documentation](https://docs.dwavequantum.com/en/latest/leap_sapi/index.html)\n"
    ]
   }
  ],

--- a/notebooks_py/5-Benchmarking_python.ipynb
+++ b/notebooks_py/5-Benchmarking_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-5-benchmarking-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Benchmarking</h1>\n",
@@ -2903,7 +2903,7 @@
     "**Further reading:**\n",
     "- [Ronnow et al., Defining and detecting quantum speedup](https://doi.org/10.1126/science.1252319)\n",
     "- [SciPy bootstrap documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html)\n",
-    "- [D-Wave Ocean benchmarking resources](https://docs.ocean.dwavesys.com/)\n"
+    "- [D-Wave Ocean benchmarking resources](https://docs.dwavequantum.com/en/latest/)\n"
    ]
   }
  ],

--- a/notebooks_py/6-QCi_python.ipynb
+++ b/notebooks_py/6-QCi_python.ipynb
@@ -1494,7 +1494,7 @@
     "\n",
     "**Further reading:**\n",
     "- [Nguyen et al., Entropy Computing, arXiv:2407.04512](https://arxiv.org/abs/2407.04512)\n",
-    "- [QCi documentation](https://quantumcomputinginc.com/learn/lessons)\n",
+    "- [QCi learning resources](https://quantumcomputinginc.com/learn/lessons)\n",
     "- [QCi Python client package](https://pypi.org/project/qci-client/)\n"
    ]
   },

--- a/notebooks_py/6-QCi_python.ipynb
+++ b/notebooks_py/6-QCi_python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"top\" id=\"top\"></a>\n",
+    "<div id=\"top-py-6-qci-python\"></div>\n",
     "\n",
     "<div align=\"center\">\n",
     "    <h1>Entropy Computing via QCi</h1>\n",
@@ -1494,7 +1494,7 @@
     "\n",
     "**Further reading:**\n",
     "- [Nguyen et al., Entropy Computing, arXiv:2407.04512](https://arxiv.org/abs/2407.04512)\n",
-    "- [QCi documentation](https://docs.quantumcomputinginc.com/)\n",
+    "- [QCi documentation](https://quantumcomputinginc.com/learn/lessons)\n",
     "- [QCi Python client package](https://pypi.org/project/qci-client/)\n"
    ]
   },

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -210,6 +210,51 @@ class JupyterBookConfigurationTests(unittest.TestCase):
                 self.assertEqual(notebook, colab_map.get(dot_route))
                 self.assertTrue((REPO_ROOT / notebook).is_file())
 
+    def test_build_book_target_builds_in_strict_mode(self) -> None:
+        makefile_source = (REPO_ROOT / "Makefile").read_text()
+
+        self.assertIn("jupyter book build --html --ci --strict", makefile_source)
+
+    def test_notebooks_do_not_reference_retired_vendor_doc_domains(self) -> None:
+        retired_domains = (
+            "docs.dwavesys.com",
+            "docs.ocean.dwavesys.com",
+            "docs.quantumcomputinginc.com",
+        )
+        offenders = [
+            f"{path.name}: {domain}"
+            for path in notebook_paths()
+            for domain in retired_domains
+            if domain in path.read_text(encoding="utf-8")
+        ]
+
+        self.assertEqual([], offenders)
+
+    def test_in_page_anchor_links_resolve_within_their_own_notebook(self) -> None:
+        anchor_definition = re.compile(r'<div id="([^"]+)"></div>')
+        in_page_link = re.compile(r'href="#([^"]+)"')
+        all_identifiers: list[str] = []
+
+        for path in notebook_paths():
+            markdown = "\n".join(
+                "".join(cell.get("source", []))
+                for cell in notebook_cells(path)
+                if cell.get("cell_type") == "markdown"
+            )
+            identifiers = anchor_definition.findall(markdown)
+            targets = in_page_link.findall(markdown)
+            all_identifiers.extend(identifiers)
+
+            with self.subTest(notebook=path.name):
+                # A link to #x must find its target in the same notebook, or the
+                # rendered book resolves it against another notebook's page.
+                self.assertEqual([], sorted(set(targets) - set(identifiers)))
+                self.assertEqual(sorted(set(identifiers)), sorted(identifiers))
+
+        # Identifiers are project-global in MyST, so a repeated one silently
+        # retargets every in-page link that uses it to a different notebook.
+        self.assertEqual(sorted(set(all_identifiers)), sorted(all_identifiers))
+
 
 class NotebookSourceSafetyTests(unittest.TestCase):
     def test_notebooks_do_not_use_jump_unsafe_backend(self) -> None:
@@ -1592,8 +1637,10 @@ class JuliaColabSetupTests(unittest.TestCase):
     def test_dwave_installation_badge_targets_existing_anchor(self) -> None:
         source = notebook_source(DWAVE_JULIA_NOTEBOOK_PATH)
 
-        self.assertIn('href="#installation"', source)
-        self.assertRegex(source, r'<a\b[^>]*(?:id|name)="installation"')
+        # Anchor identifiers are notebook-scoped so MyST cannot resolve an
+        # in-page link against a different notebook's page.
+        self.assertIn('href="#installation-jl-4-dwave"', source)
+        self.assertIn('<div id="installation-jl-4-dwave"></div>', source)
 
     def test_bootstrap_supports_native_colab_runtime_failure_modes(self) -> None:
         source = BOOTSTRAP_PATH.read_text()

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -142,6 +142,14 @@ def notebook_solution_output_texts(path: Path) -> list[str]:
     return outputs
 
 
+def notebook_markdown(path: Path) -> str:
+    return "\n".join(
+        "".join(cell.get("source", []))
+        for cell in notebook_cells(path)
+        if cell.get("cell_type") == "markdown"
+    )
+
+
 def notebook_paths() -> list[Path]:
     return sorted(path for directory in NOTEBOOK_DIRS for path in directory.glob("*.ipynb"))
 
@@ -215,18 +223,68 @@ class JupyterBookConfigurationTests(unittest.TestCase):
 
         self.assertIn("jupyter book build --html --ci --strict", makefile_source)
 
+    def test_strict_build_does_not_gate_on_third_party_availability(self) -> None:
+        myst_source = (REPO_ROOT / "myst.yml").read_text()
+        severities = dict(
+            re.findall(
+                r"-\s+id:\s+([a-z0-9-]+)\s*\n\s+severity:\s+([a-z]+)",
+                myst_source,
+            )
+        )
+
+        # Reaching third-party URLs must not decide whether the build passes;
+        # the build gates every merge and every Pages deployment.
+        self.assertEqual("warn", severities.get("link-resolves"))
+        self.assertEqual("warn", severities.get("doi-link-valid"))
+        # Unresolved cross-references are a repository defect, so they stay fatal.
+        self.assertEqual("error", severities.get("reference-target-resolves"))
+
     def test_notebooks_do_not_reference_retired_vendor_doc_domains(self) -> None:
         retired_domains = (
             "docs.dwavesys.com",
             "docs.ocean.dwavesys.com",
             "docs.quantumcomputinginc.com",
         )
-        offenders = [
-            f"{path.name}: {domain}"
-            for path in notebook_paths()
-            for domain in retired_domains
-            if domain in path.read_text(encoding="utf-8")
+        # Scoped to markdown so a domain that legitimately appears in committed
+        # cell output cannot fail a documentation-link guard.
+        offenders = []
+        for path in notebook_paths():
+            markdown = "\n".join(
+                "".join(cell.get("source", []))
+                for cell in notebook_cells(path)
+                if cell.get("cell_type") == "markdown"
+            )
+            offenders.extend(
+                f"{path.name}: {domain}"
+                for domain in retired_domains
+                if domain in markdown
+            )
+
+        self.assertEqual([], offenders)
+
+    def test_relative_links_point_at_files_that_exist(self) -> None:
+        # The book build reports unreachable URLs as warnings so third-party
+        # downtime cannot gate a merge. Internal link integrity is this
+        # repository's own responsibility, so it is checked here instead, with
+        # no network access and therefore no flakiness.
+        relative_link = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+        skipped_schemes = ("http://", "https://", "mailto:", "data:", "attachment:", "#")
+        offenders = []
+
+        documents = [(path, path.parent, notebook_markdown(path)) for path in notebook_paths()]
+        documents += [
+            (REPO_ROOT / name, REPO_ROOT, (REPO_ROOT / name).read_text(encoding="utf-8"))
+            for name in ("index.md", "local-setup.md", "README.md")
+            if (REPO_ROOT / name).is_file()
         ]
+
+        for source_path, base_dir, text in documents:
+            for target in relative_link.findall(text):
+                if target.startswith(skipped_schemes):
+                    continue
+                resolved = (base_dir / target.split("#", 1)[0]).resolve()
+                if not resolved.exists():
+                    offenders.append(f"{source_path.name} -> {target}")
 
         self.assertEqual([], offenders)
 


### PR DESCRIPTION
Closes #122.

## Summary

- repoint the retired D-Wave and QCi documentation domains at their current homes
- scope every in-page anchor identifier to its own notebook so MyST resolves
  back-to-top links locally instead of across notebooks
- build the Jupyter Book with `--strict` so link and reference defects fail CI
- add regression tests for the strict gate, the retired domains, and the
  anchor/link invariant

## Why

The `build` job added in #121 only proved the build did not crash. `--ci` is a
mode indicator, not a strictness flag, and the previous command performed **zero**
link checks: a book with a broken file link, a dead external URL, and a dangling
cross-reference built with exit code 0.

Turning `--strict` on was not a one-line change because the collection already
had 48 errors and 23 warnings, so this PR fixes the underlying defects first.

### A real navigation bug, not just noise

Every notebook opened with `<a name="top" id="top"></a>`. Two distinct problems:

1. An `<a>` with no `href` is a link with no URL, which is what produced 18 of
   the errors.
2. MyST identifiers are project-global, so 17 notebooks all declaring `top` made
   every `#top` link resolve to whichever notebook was indexed first. The
   rendered Julia notebook 1 page linked to the **Python** notebook 1 page:
   `href="/QUBONotebooks/notebooks-py/mathprog-python#top"`.

Anchors are now `<div id="top-jl-1-mathprog"></div>` and similar. A `div` carries
the fragment target for Colab and Jupyter without being a link, and the
notebook-scoped identifier makes each in-page link resolve to its own page.
Back-to-top links now render as same-page fragments with no cross-page leaks.

### Retired documentation domains

D-Wave moved its documentation to `docs.dwavequantum.com`; the old paths redirect
and then 404. QCi's `docs.quantumcomputinginc.com` no longer resolves in DNS at
all. Each replacement below was verified to return 200 without landing on a
login wall.

| Retired | Replacement |
|---|---|
| `docs.dwavesys.com/docs/latest/leap.html` | `docs.dwavequantum.com/en/latest/leap_sapi/index.html` |
| `docs.ocean.dwavesys.com/projects/dimod/en/stable/` | `docs.dwavequantum.com/en/latest/ocean/api_ref_dimod/index.html` |
| `docs.ocean.dwavesys.com/projects/neal/en/latest/` | `docs.dwavequantum.com/en/latest/ocean/api_ref_samplers/index.html` |
| `docs.ocean.dwavesys.com/projects/system/en/stable/` | `docs.dwavequantum.com/en/latest/ocean/api_ref_system/index.html` |
| `docs.ocean.dwavesys.com/en/stable/examples/map_coloring.html` | `docs.dwavequantum.com/en/latest/quantum_research/example_mapcoloring.html` |
| `docs.ocean.dwavesys.com/en/stable/concepts/index.html` | `docs.dwavequantum.com/en/latest/concepts/index.html` |
| `docs.quantumcomputinginc.com/` | `quantumcomputinginc.com/learn/lessons` |
| `docs.ocean.dwavesys.com/` | `docs.dwavequantum.com/en/latest/` |

The `concepts` link did not 404 outright, but it now redirects to a ReadTheDocs
login wall, so it is repointed with the rest of the migration.

## Notebook safety

The diff touches **markdown sources only**. Cell outputs, execution counts, code
sources, and notebook metadata are byte-identical to `main` for all 17 notebooks,
so the committed D-Wave QPU and QCi cloud results are preserved and no notebook
was re-executed.

## Acceptance criteria

- [x] `BASE_URL=/QUBONotebooks make build-book` exits 0 with `--strict` enabled.
- [x] No external link in any notebook returns 404 in the strict link check.
- [x] `Makefile`'s `build-book` target passes `--strict`.
- [x] The build fails when a broken link or dangling reference is introduced —
  split across two deterministic checks, see "What the gate actually gates".

## What the gate actually gates

Review found that `--strict` alone did not satisfy the fourth criterion and was
unsafe as a merge gate, so the gate is now split by who owns the failure.

A dangling cross-reference is only a *warning* in MyST, so `--strict` on its own
never failed on one. More seriously, `--strict` enables external link checking,
which made the build depend on ~190 URLs across 29 third-party hosts. Rebuilding
unchanged content produced five distinct transient failures — `doi.org` 403,
`doi.org` citation lookup, `img.shields.io` ECONNRESET, a Colab timeout, and even
a `docs.dwavequantum.com` URL this PR adds that returns 200 on demand. Since
`deploy` declares `needs: build`, that would have intermittently blocked Pages
deployment on `main`.

`myst.yml` now sets `error_rules` so the split is explicit:

| Failure | Severity | Rationale |
|---|---|---|
| Unresolved cross-reference | error | repository defect |
| Unreachable external URL | warn | third-party uptime, not ours |
| DOI metadata lookup | warn | third-party uptime, not ours |

Internal relative links are no longer covered by the build, so
`test_relative_links_point_at_files_that_exist` covers them locally with no
network access and therefore no flakiness.

## Verification

- `make build-book` with `BASE_URL=/QUBONotebooks` — exit 0, 19 pages, 18 files
  link-checked, **zero** errors and warnings (was 48 errors / 23 warnings).
- Gate proven live: a dangling cross-reference alone makes `make build-book`
  exit 2, and a broken relative link fails the new local test.
- Determinism proven: three consecutive clean builds each exit 0 with zero
  errors while warning counts varied (4, 0, 1) purely from external hosts.
- `make test-python` — 211 tests passed (206 before, 5 added).
- `make test`, `make test-julia`, `make check-notebook-output-hygiene`,
  `uv lock --check`, `git diff --check` — all passed.
- Rendered-output check: every back-to-top link is a same-page fragment and no
  page still references the old shared `#top`.
- Mutation proofs for the new tests — reintroducing a duplicate `top` identifier,
  leaving an in-page link dangling, and reverting `--strict` each turn the
  relevant test red.
- Every replacement URL checked with `curl` for status and final landing URL.

## Out of scope

The issue's "related, smaller" note about workflow `paths:` filters not covering
non-Markdown assets is left alone deliberately: no notebook or page references a
repo-local asset file today (every image is embedded or external), so the gap has
no current effect. Worth a separate issue if local assets are ever added.

## Branch Hygiene

Base `main`, branched from `d09df91` (the #121 merge). No stacked prerequisites.
Open PR #120 touches only `pyproject.toml` and `uv.lock`, so there is no overlap.

