### PR TITLE
Document test design and replace Makefile source snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ make verify-colab-bootstrap-output JULIA="julia +1.12"
 make verify-colab-hosted
 ```
 
+### Test design
+
+Add a test when it protects a contract that can fail silently:
+
+- derive and compare both sides of a relationship that must stay synchronized;
+- execute behavior and assert its result; or
+- guard a deliberate policy whose removal would otherwise leave every check
+  green.
+
+Avoid pinning documentation wording, literal notebook source lines, or build
+target declarations. Invoking a build target is the behavioral check for
+whether it exists. When a literal is unavoidable, use the narrowest stable
+symbol or configuration key and leave a comment naming the recurring defect
+class it protects.
+
 ### Python verification environment
 
 The generic verifier can execute selected notebooks by overriding `NOTEBOOKS`

--- a/tests/makefile_support.py
+++ b/tests/makefile_support.py
@@ -1,0 +1,15 @@
+"""Helpers for testing evaluated Make behavior instead of Makefile source."""
+
+from __future__ import annotations
+
+import shlex
+
+
+def command_with_assignment(output: str, name: str) -> list[str]:
+    """Return the evaluated Make command carrying a named assignment."""
+    prefix = f"{name}="
+    for line in output.splitlines():
+        command = shlex.split(line)
+        if any(token.startswith(prefix) for token in command):
+            return command
+    raise AssertionError(f"No Make command assigned {name}")

--- a/tests/test_qci_julia_notebook.py
+++ b/tests/test_qci_julia_notebook.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import itertools
 import json
+import os
 import re
+import subprocess
 import tomllib
 import unittest
 from pathlib import Path
+
+from makefile_support import command_with_assignment
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -208,7 +212,7 @@ class QCIJuliaNotebookTests(unittest.TestCase):
             live_source,
         )
 
-    def test_environment_readme_makefile_and_bootstrap_are_linked(self) -> None:
+    def test_environment_readme_and_bootstrap_are_linked(self) -> None:
         data = notebook()
         source = notebook_source()
         project = tomllib.loads(
@@ -217,7 +221,6 @@ class QCIJuliaNotebookTests(unittest.TestCase):
         pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
         manifest = (REPO_ROOT / "notebooks_jl" / "Manifest.toml").read_text()
         readme = (REPO_ROOT / "README.md").read_text()
-        makefile = (REPO_ROOT / "Makefile").read_text()
         bootstrap = (
             REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
         ).read_text()
@@ -234,15 +237,6 @@ class QCIJuliaNotebookTests(unittest.TestCase):
         )
         self.assertIn("notebooks_jl/6-QCi.ipynb", readme)
         self.assertIn("make verify-qci-julia-local", readme)
-        self.assertIn("verify-qci-julia-local:", makefile)
-        self.assertIn("verify-qci-julia-cloud:", makefile)
-        self.assertIn(
-            "QUBONOTEBOOKS_QCI_ENABLE_CLOUD=0 "
-            "QUBONOTEBOOKS_QCI_REQUIRE_CLOUD=0",
-            makefile,
-        )
-        self.assertIn('UV_GROUP_FLAGS="--group docs"', makefile)
-        self.assertIn('NOTEBOOKS="$(QCI_JULIA_NOTEBOOK)"', makefile)
         self.assertNotIn("qci", pyproject["dependency-groups"])
         self.assertNotIn("qiskit", pyproject["dependency-groups"])
         self.assertNotIn("conflicts", pyproject["tool"]["uv"])
@@ -250,10 +244,6 @@ class QCIJuliaNotebookTests(unittest.TestCase):
         self.assertIn("using JuMP, QCIOpt", bootstrap)
         self.assertIn("import MathOptInterface as MOI", bootstrap)
         self.assertNotIn("qci-client", bootstrap)
-        self.assertIn(
-            "env -u JULIA_CONDAPKG_BACKEND -u JULIA_PYTHONCALL_EXE",
-            makefile,
-        )
         self.assertIn('withenv("QCI_TOKEN" => nothing)', bootstrap)
         self.assertNotIn("qci-client>=", source)
         self.assertNotIn("pip install qci-client", source)
@@ -266,6 +256,74 @@ class QCIJuliaNotebookTests(unittest.TestCase):
         self.assertEqual(
             {"display_name": "Julia", "language": "julia", "name": "julia"},
             data["metadata"]["kernelspec"],
+        )
+
+    def test_local_target_masks_cloud_state_and_selects_qci_notebook(self) -> None:
+        env = os.environ.copy()
+        env.pop("MAKEFLAGS", None)
+        env.pop("MFLAGS", None)
+        # Hostile ambient values must not turn the local check into a QCI job.
+        env.update(
+            {
+                "QCI_TOKEN": "test-only",
+                "QUBONOTEBOOKS_QCI_ENABLE_CLOUD": "1",
+                "QUBONOTEBOOKS_QCI_REQUIRE_CLOUD": "1",
+            }
+        )
+        completed = subprocess.run(
+            ["make", "--dry-run", "verify-qci-julia-local"],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        command = command_with_assignment(completed.stdout, "NOTEBOOKS")
+        assignments = dict(
+            token.split("=", 1) for token in command if "=" in token
+        )
+
+        self.assertEqual(
+            [
+                "env",
+                "-u",
+                "JULIA_CONDAPKG_BACKEND",
+                "-u",
+                "JULIA_PYTHONCALL_EXE",
+                "-u",
+                "QCI_TOKEN",
+            ],
+            command[:7],
+        )
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_QCI_ENABLE_CLOUD"])
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_QCI_REQUIRE_CLOUD"])
+        self.assertEqual("--group docs", assignments["UV_GROUP_FLAGS"])
+        self.assertEqual("notebooks_jl/6-QCi.ipynb", assignments["NOTEBOOKS"])
+
+    def test_cloud_target_fails_closed_without_opt_in(self) -> None:
+        env = os.environ.copy()
+        env.pop("MAKEFLAGS", None)
+        env.pop("MFLAGS", None)
+        for variable in (
+            "QCI_TOKEN",
+            "QUBONOTEBOOKS_QCI_ENABLE_CLOUD",
+            "QUBONOTEBOOKS_QCI_REQUIRE_CLOUD",
+        ):
+            env.pop(variable, None)
+        completed = subprocess.run(
+            ["make", "verify-qci-julia-cloud"],
+            cwd=REPO_ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(2, completed.returncode)
+        self.assertIn(
+            "QUBONOTEBOOKS_QCI_ENABLE_CLOUD",
+            completed.stdout + completed.stderr,
         )
 
     def test_committed_outputs_publish_sanitized_qci_results(self) -> None:

--- a/tests/test_starter_series_integration.py
+++ b/tests/test_starter_series_integration.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
 import unittest
 from pathlib import Path
+
+from makefile_support import command_with_assignment
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 README_PATH = REPO_ROOT / "README.md"
-MAKEFILE_PATH = REPO_ROOT / "Makefile"
 BOOTSTRAP_PATH = REPO_ROOT / "scripts" / "notebook_bootstrap.jl"
 
 STARTER_NOTEBOOK_IMPORTS = {
@@ -139,74 +142,82 @@ class StarterSeriesBootstrapTests(unittest.TestCase):
 
 
 class StarterSeriesVerificationTargetTests(unittest.TestCase):
-    def test_makefile_exposes_local_aggregate_and_opt_in_targets(self) -> None:
-        makefile = MAKEFILE_PATH.read_text()
+    def test_local_aggregate_selects_each_notebook_and_disables_remote_paths(
+        self,
+    ) -> None:
+        env = os.environ.copy()
+        env.pop("MAKEFLAGS", None)
+        env.pop("MFLAGS", None)
+        # Hostile ambient values must not turn the local aggregate into a
+        # remote-service submission.
+        env.update(
+            {
+                "QUBONOTEBOOKS_QAOA_ENABLE_IBM": "1",
+                "QUBONOTEBOOKS_QAOA_REQUIRE_IBM": "1",
+                "QUBONOTEBOOKS_ANNEALING_ENABLE_QPU": "1",
+                "QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU": "1",
+            }
+        )
+        completed = subprocess.run(
+            ["make", "--dry-run", "verify-five-starter-problems-julia-local"],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
-        for target in (
-            "verify-canonical-problems-julia:",
-            "verify-order-partitioning-julia:",
-            "verify-cancer-genomics-julia:",
-            "verify-qaoa-julia-local:",
-            "verify-annealing-julia-local:",
-            "verify-five-starter-problems-julia-local:",
-            "verify-qaoa-julia-ibm:",
-            "verify-annealing-julia-qpu:",
+        command = command_with_assignment(completed.stdout, "NOTEBOOKS")
+        assignments = dict(
+            token.split("=", 1) for token in command if "=" in token
+        )
+        expected_notebooks = {
+            str(path.relative_to(REPO_ROOT)) for path in STARTER_NOTEBOOK_PATHS
+        }
+
+        self.assertEqual(
+            expected_notebooks,
+            set(assignments["NOTEBOOKS"].split()),
+        )
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_QAOA_ENABLE_IBM"])
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_QAOA_REQUIRE_IBM"])
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_ANNEALING_ENABLE_QPU"])
+        self.assertEqual("0", assignments["QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU"])
+
+    def test_remote_hardware_targets_fail_closed_without_opt_in(self) -> None:
+        env = os.environ.copy()
+        env.pop("MAKEFLAGS", None)
+        env.pop("MFLAGS", None)
+        for variable in (
+            "QUBONOTEBOOKS_QAOA_ENABLE_IBM",
+            "QUBONOTEBOOKS_QAOA_REQUIRE_IBM",
+            "QUBONOTEBOOKS_QAOA_IBM_BACKEND",
+            "QISKIT_IBM_TOKEN",
+            "QUBONOTEBOOKS_ANNEALING_ENABLE_QPU",
+            "QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU",
+            "DWAVE_API_TOKEN",
+        ):
+            env.pop(variable, None)
+
+        for target, required_opt_in in (
+            ("verify-qaoa-julia-ibm", "QUBONOTEBOOKS_QAOA_ENABLE_IBM"),
+            ("verify-annealing-julia-qpu", "QUBONOTEBOOKS_ANNEALING_ENABLE_QPU"),
         ):
             with self.subTest(target=target):
-                self.assertIn(target, makefile)
+                completed = subprocess.run(
+                    ["make", target],
+                    cwd=REPO_ROOT,
+                    env=env,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
 
-        self.assertIn("FIVE_STARTER_JULIA_NOTEBOOKS", makefile)
-        for path in STARTER_NOTEBOOK_PATHS:
-            with self.subTest(notebook=path.name):
-                self.assertIn(f"notebooks_jl/{path.name}", makefile)
-
-        self.assertIn("QUBONOTEBOOKS_QAOA_ENABLE_IBM", makefile)
-        self.assertIn("QUBONOTEBOOKS_QAOA_REQUIRE_IBM", makefile)
-        self.assertIn("QUBONOTEBOOKS_QAOA_IBM_BACKEND", makefile)
-        self.assertIn("QISKIT_IBM_TOKEN", makefile)
-        self.assertIn("QUBONOTEBOOKS_ANNEALING_ENABLE_QPU", makefile)
-        self.assertIn("QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU", makefile)
-        self.assertIn("DWAVE_API_TOKEN", makefile)
-
-        def recipe(target: str) -> str:
-            match = re.search(
-                rf"(?m)^{re.escape(target)}:\n((?:\t.*\n)+)",
-                makefile,
-            )
-            self.assertIsNotNone(match)
-            return match.group(1)
-
-        self.assertIn(
-            "QUBONOTEBOOKS_QAOA_ENABLE_IBM=0",
-            recipe("verify-qaoa-julia-local"),
-        )
-        self.assertIn(
-            "QUBONOTEBOOKS_QAOA_REQUIRE_IBM=0",
-            recipe("verify-qaoa-julia-local"),
-        )
-        self.assertIn(
-            "QUBONOTEBOOKS_ANNEALING_ENABLE_QPU=0",
-            recipe("verify-annealing-julia-local"),
-        )
-        self.assertIn(
-            "QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU=0",
-            recipe("verify-annealing-julia-local"),
-        )
-        self.assertIn(
-            "QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU=1",
-            recipe("verify-annealing-julia-qpu"),
-        )
-        aggregate_recipe = recipe("verify-five-starter-problems-julia-local")
-        self.assertIn("QUBONOTEBOOKS_QAOA_ENABLE_IBM=0", aggregate_recipe)
-        self.assertIn("QUBONOTEBOOKS_QAOA_REQUIRE_IBM=0", aggregate_recipe)
-        self.assertIn(
-            "QUBONOTEBOOKS_ANNEALING_ENABLE_QPU=0",
-            aggregate_recipe,
-        )
-        self.assertIn(
-            "QUBONOTEBOOKS_ANNEALING_REQUIRE_QPU=0",
-            aggregate_recipe,
-        )
+                self.assertEqual(2, completed.returncode)
+                self.assertIn(
+                    required_opt_in,
+                    completed.stdout + completed.stderr,
+                )
 
     def test_readme_documents_targets_runtime_and_environment_contracts(self) -> None:
         readme = README_PATH.read_text()

--- a/tests/test_verify_notebooks.py
+++ b/tests/test_verify_notebooks.py
@@ -1602,36 +1602,6 @@ class CommandConstructionTests(unittest.TestCase):
 
 
 class RepositoryCommandTests(unittest.TestCase):
-    def test_makefile_exposes_verification_targets(self) -> None:
-        makefile = (REPO_ROOT / "Makefile").read_text()
-
-        self.assertIn("test-python:", makefile)
-        self.assertIn("test-julia:", makefile)
-        self.assertIn("check-notebook-output-hygiene:", makefile)
-        self.assertIn("clear-notebook-outputs:", makefile)
-        self.assertIn("verify-notebooks:", makefile)
-        self.assertIn("verify-python-portable:", makefile)
-        self.assertIn("verify-qubo-python:", makefile)
-        self.assertIn("verify-gama-python:", makefile)
-        self.assertIn("verify-benchmarking-python:", makefile)
-        self.assertIn("verify-qaoa-julia-local:", makefile)
-        self.assertIn("PORTABLE_PYTHON_NOTEBOOKS", makefile)
-        self.assertIn("ClearOutputPreprocessor.enabled=True", makefile)
-        self.assertIn("git grep -lE", makefile)
-        self.assertNotIn("git grep -nE 'C:", makefile)
-        self.assertIn("purdue-internship", makefile)
-        self.assertIn("QUBONotebooksFork", makefile)
-        self.assertIn("./scripts/verify_notebooks.py", makefile)
-        self.assertIn("--project=./notebooks_jl", makefile)
-        self.assertIn("$(UV) sync --locked", makefile)
-        self.assertIn("$(UV) run --locked", makefile)
-
-    def test_ci_runs_notebook_output_hygiene_check(self) -> None:
-        ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
-
-        self.assertIn("Notebook output hygiene", ci_workflow)
-        self.assertIn("make check-notebook-output-hygiene", ci_workflow)
-
     def test_locked_python_environment_excludes_unpatched_diskcache_path(self) -> None:
         pyproject = (REPO_ROOT / "pyproject.toml").read_text()
         lock = (REPO_ROOT / "uv.lock").read_text()


### PR DESCRIPTION
## Summary

- document the repository's durable test-design rule near its verification commands
- remove broad assertions over Makefile and CI source text
- replace the policy-bearing cases with behavioral Make checks for notebook selection, local/cloud isolation, and fail-closed service opt-ins
- share the Make-output parser between the focused test modules

This is the first reviewable cleanup slice from #125, covering the proposed rule and the highest-ranked Makefile-target snapshots. It intentionally does not attempt the topology/results-cache conversions or the large test-module split.

## Issue acceptance criteria

- [x] The testing rule is written down in the repository.
- [ ] Substring assertions fall below 40% of total assertions. This slice moves the source-level count from 722/1,084 (66.6%) to 677/1,050 (64.5%).
- [ ] No test asserts a Makefile target name that CI already exercises. The broad ranked snapshots are removed here; smaller notebook-specific integration snapshots remain for later per-test decisions.
- [ ] `test_verify_notebooks.py` is under about 800 lines, or split into focused modules.
- [ ] Every remaining source-pinning test carries a comment naming the defect class it guards.
- [ ] A behavior-neutral notebook prose or local-variable edit breaks no test.

Merging this PR leaves #125 open. Later focused PRs should convert or delete the remaining source-pinning tests, split `test_verify_notebooks.py`, and re-measure the final suite before the issue closes.

## Validation

- `uv --cache-dir .uv-cache lock --check`
- `make test`
- `make test-python PYTHON="uv --cache-dir .uv-cache run --locked --group docs python"` — 210 tests passed
- `git diff --check origin/main...HEAD`
- mutation checks confirmed the new behavior tests fail when a starter notebook is dropped, a local aggregate leaks a remote-enable flag, the QCI local target stops masking `QCI_TOKEN`, or the QCI/IBM opt-in guards are weakened
- `make build-book` was attempted but this machine has Node without npm, so Jupyter Book stopped during its toolchain preflight before reading project content; the PR's current-head docs workflow remains the authoritative build

## External services

QCI, IBM Quantum, and D-Wave were not contacted or changed. The tests remove credentials from their subprocess environments and verify the Make targets stop before submission unless a user explicitly opts in.

## Branch hygiene

- base: `main` at `eefea3a6e8d347af435b051e11635ac3b6ac76e7`
- head: `refactor/issue-125-test-contract-phase-1`
- stacked: no
- overlapping open PRs at branch creation: none

Refs #125
