### PR TITLE
Record the notebook maintenance and output-size policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,17 +45,18 @@ mirrored.
 ### Contracts that bind every notebook
 
 These hold for all seventeen notebooks in both families and are enforced by
-`tests/test_notebook_structure.py`. Run `make test` before opening a pull
-request.
+`tests/test_notebook_structure.py`, which runs under `make test-python`. Run
+it before opening a pull request. `make test` is a separate target covering
+the repository link policy, not these contracts.
 
 | Contract | What it requires |
 | --- | --- |
-| Masthead | The first cell is markdown and opens with the exact shared block: one H1 matching the notebook's `myst.yml` table-of-contents title, its anchor `<div>`, the JuliaQUBO attribution, the SECQUOIA and PSR Energy links, and a Colab badge pointing at the notebook's own path. |
+| Masthead | The first cell is markdown and opens with the exact shared block: one H1 matching the notebook's `myst.yml` table-of-contents title, its anchor `<div>`, the JuliaQUBO attribution, the SECQUOIA and PSR Energy links, and a Colab badge. The badge URL is pinned to this repository on `main` and to the notebook's own path, so a badge repointed at a fork or a feature branch fails. |
 | Single H1 | Exactly one level-one heading per notebook, and no raw `<h1>`. |
 | Heading hierarchy | No heading level is skipped outside fenced code blocks, so the rendered page has a navigable section tree. |
 | Unindented raw HTML | Every line of a raw-HTML markdown block starts at column zero. A four-space indent publishes the tags as literal source in engines without CommonMark HTML blocks. |
 | Hidden installation cells | Installation, bootstrap, and `versioninfo()` code cells, and any install-titled section outside `## Setup`, carry both the `hide-cell` and `installation` tags. |
-| Exercise checkpoints | At least three `# EXERCISE` cells and three `# SOLUTION` cells, with the first three solutions tagged `hide-cell` and `solution` and containing real code. |
+| Exercise checkpoints | At least three cells marked `# EXERCISE` and three marked with the exact string `# SOLUTION (hidden in workshop version):` — the short `# SOLUTION` form is not counted. The first three solution cells carry the `hide-cell` and `solution` tags; every solution cell must contain real code, not only comments. |
 | Footer structure | Acknowledgments sections and back-to-top links are selected structurally, by heading and in-page anchor, rather than by prose phrase. |
 | In-page anchors | Anchor identifiers are unique across the whole project, and every `#`-link resolves inside its own notebook. |
 | Relative links | Every relative link in a notebook, `index.md`, `local-setup.md`, `README.md`, or this file resolves to a file that exists. |
@@ -102,19 +103,27 @@ not the notebook's file size.
 
 ### Documented exceptions
 
-These exceed a budget by deliberate grant rather than by accident. Each one
-publishes benchmark or solver-progress figures that carry the lesson:
+These exceed a budget by deliberate grant rather than by accident:
 
-| Notebook or cell | Budget exceeded | Reason |
+| Notebook or cell | Budget exceeded | What the stored output is |
 | --- | --- | --- |
-| `notebooks_py/5-Benchmarking_python.ipynb` | notebook, and one cell | Benchmark comparison figures across solver families |
-| `notebooks_jl/5-Benchmarking.ipynb` | notebook, and one cell | Julia benchmark figures for the same comparison |
-| `notebooks_py/1-MathProg_python.ipynb` | notebook | Repeated feasible-region and branch-and-bound plots |
-| `notebooks_py/4-DWAVE_python.ipynb` | two cells | Embedding and sampler-result visualizations |
+| `notebooks_py/5-Benchmarking_python.ipynb` | notebook, and one cell | A `nx.draw` spring-layout rendering of the random Ising model graph |
+| `notebooks_jl/5-Benchmarking.ipynb` | notebook, and one cell | A circular-layout plot of the same Ising graph |
+| `notebooks_py/4-DWAVE_python.ipynb` | two cells | The QPU topology graph and the minor-embedding graph |
+| `notebooks_py/1-MathProg_python.ipynb` | notebook | Nine stored plots holding 1.14 MB of the notebook's 1.16 MB. Eight are near-identical redraws of the same feasible region, each adding one annotation for the LP, ILP, convex INLP, and nonconvex INLP solutions; the ninth is an unrelated complexity-growth plot |
+
+Two different failures are visible in that table, and they need different
+remedies. Every cell over the per-cell budget is a dense graph-layout render,
+where the lever is rasterization and resolution rather than fewer results.
+`1-MathProg_python` is the opposite case: no single cell is close to the
+per-cell budget, and the notebook is over only because one figure is stored
+eight times over. That duplication is exactly what the per-notebook budget
+exists to catch.
 
 An exception is a decision to revisit, not a permanent allowance. Reducing a
-grant, by rendering a figure at a lower resolution or in a more compact
-format, is an improvement as long as the instruction survives it.
+grant, by rendering a figure at a lower resolution or in a more compact format
+or by not re-emitting an unchanged figure, is an improvement as long as the
+instruction survives it.
 
 ### Changing outputs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing
+
+This file records the editorial contracts for the notebook collection: what
+each notebook family promises, what binds every notebook regardless of
+language, and how much committed output a notebook may carry.
+
+Operational documentation lives elsewhere. The [README](README.md) covers
+dependency groups, verification targets, and the Julia and Colab environments;
+[local-setup.md](local-setup.md) covers building the book and re-executing
+notebooks locally.
+
+## Notebook families
+
+The repository publishes eleven Julia notebooks and six Python notebooks.
+Notebooks 1 through 6 exist in both languages; notebooks 7 through 11 are Julia
+only.
+
+### The Python notebooks are on-ramps, not mirrors
+
+The Python notebooks are introductory on-ramps. Most people arriving at
+quantum optimization arrive from Python, and Pyomo, `dimod`, `neal`, and
+`eqc_models` are Python-native APIs that read most naturally there. The paired
+presentation is deliberate pedagogy: the same model in both languages, then a
+push toward the Julia tooling that the rest of the collection builds on.
+
+They are maintained for correctness and for the shared contracts listed below.
+
+They are **not** maintained for structural parity with their Julia
+counterparts. A Python notebook may use different section names, a different
+number of sections, a different example, or a different ordering than the
+Julia notebook it is paired with, and that is not a defect.
+
+The reason is drift. An implied mirror turns a single convention change into a
+seventeen-file edit, and the mirror then slips in ways that look like
+sloppiness: one family's section renamed while the other kept the old title,
+one family abbreviating a term the other spells out. Requiring parity without
+enforcing it produces exactly that class of defect and no way to catch it.
+Notebooks 7 through 11 already have no Python counterpart, so the asymmetry is
+the existing precedent rather than a new concession.
+
+A change that *does* alter a shared contract must be applied to both families.
+A change that only reorganizes one notebook's prose or examples need not be
+mirrored.
+
+### Contracts that bind every notebook
+
+These hold for all seventeen notebooks in both families and are enforced by
+`tests/test_notebook_structure.py`. Run `make test` before opening a pull
+request.
+
+| Contract | What it requires |
+| --- | --- |
+| Masthead | The first cell is markdown and opens with the exact shared block: one H1 matching the notebook's `myst.yml` table-of-contents title, its anchor `<div>`, the JuliaQUBO attribution, the SECQUOIA and PSR Energy links, and a Colab badge pointing at the notebook's own path. |
+| Single H1 | Exactly one level-one heading per notebook, and no raw `<h1>`. |
+| Heading hierarchy | No heading level is skipped outside fenced code blocks, so the rendered page has a navigable section tree. |
+| Unindented raw HTML | Every line of a raw-HTML markdown block starts at column zero. A four-space indent publishes the tags as literal source in engines without CommonMark HTML blocks. |
+| Hidden installation cells | Installation, bootstrap, and `versioninfo()` code cells, and any install-titled section outside `## Setup`, carry both the `hide-cell` and `installation` tags. |
+| Exercise checkpoints | At least three `# EXERCISE` cells and three `# SOLUTION` cells, with the first three solutions tagged `hide-cell` and `solution` and containing real code. |
+| Footer structure | Acknowledgments sections and back-to-top links are selected structurally, by heading and in-page anchor, rather than by prose phrase. |
+| In-page anchors | Anchor identifiers are unique across the whole project, and every `#`-link resolves inside its own notebook. |
+| Relative links | Every relative link in a notebook, `index.md`, `local-setup.md`, `README.md`, or this file resolves to a file that exists. |
+| Colab routes | Every notebook in the table of contents has both a slash and a dot route in `colab.html`, with no duplicate keys. |
+
+One further contract binds the Python family alone: Python notebooks carry
+portable `python3` kernel metadata, so they open without a machine-specific
+kernel name.
+
+### Table of contents
+
+The book's table of contents presents each Julia and Python pair as equals,
+and that is deliberate. Both notebooks in a pair are published, correct, and
+maintained; labelling the Python entry as secondary in the navigation would
+misrepresent the paired pedagogy and read as "unmaintained", which is the
+opposite of the contract above. The asymmetry that a reader needs is already
+structural: notebooks 7 through 11 appear under their own Julia section, and
+the notebook map in [index.md](index.md) marks their missing Python
+counterparts.
+
+## Committed notebook outputs
+
+Notebook outputs are generated before publication and committed. The book
+build never executes a notebook, so committed outputs are what the published
+site renders, and they keep the book reproducible without putting solver
+credentials into GitHub Actions or spending cloud credits on every docs build.
+
+Clearing outputs is therefore not an acceptable way to shrink a notebook.
+
+### Size budgets
+
+Stored output is the dominant term in this repository's artifact size, and a
+re-execution can add a large image or a duplicated payload without any visible
+change to the lesson. These budgets bound that drift:
+
+| Scope | Budget |
+| --- | --- |
+| One code cell | 256 KB of stored output |
+| One notebook | 1.0 MB of stored output |
+| All notebooks | 10 MB of stored output |
+
+Measure stored output as the serialized `outputs` array of every code cell,
+not the notebook's file size.
+
+### Documented exceptions
+
+These exceed a budget by deliberate grant rather than by accident. Each one
+publishes benchmark or solver-progress figures that carry the lesson:
+
+| Notebook or cell | Budget exceeded | Reason |
+| --- | --- | --- |
+| `notebooks_py/5-Benchmarking_python.ipynb` | notebook, and one cell | Benchmark comparison figures across solver families |
+| `notebooks_jl/5-Benchmarking.ipynb` | notebook, and one cell | Julia benchmark figures for the same comparison |
+| `notebooks_py/1-MathProg_python.ipynb` | notebook | Repeated feasible-region and branch-and-bound plots |
+| `notebooks_py/4-DWAVE_python.ipynb` | two cells | Embedding and sampler-result visualizations |
+
+An exception is a decision to revisit, not a permanent allowance. Reducing a
+grant, by rendering a figure at a lower resolution or in a more compact
+format, is an improvement as long as the instruction survives it.
+
+### Changing outputs
+
+When a change re-executes a notebook, check the resulting stored-output size
+against the budgets above. Growth past a budget needs either a reduction or a
+new documented exception in the table, decided in review rather than merged
+silently. Adding a figure to a notebook that already holds an exception is the
+case most likely to pass unnoticed.
+
+Committed outputs must not carry credentials, tokens, or machine-specific
+absolute paths; `make check-notebook-output-hygiene` guards the known personal
+path patterns.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This collection is maintained by the
 [PSR Energy](https://www.psr-inc.com/). Individual notebook contributors are
 credited in the Acknowledgments section at the end of each notebook.
 
+[CONTRIBUTING.md](CONTRIBUTING.md) records the editorial contracts: what each
+notebook family promises, the structural contracts that bind every notebook,
+and the committed-output size budgets.
+
 ## Read the notebooks online
 
 The notebooks are published as a Jupyter Book at
@@ -68,6 +72,11 @@ This repository keeps Julia and Python variants of the QuIP/QuIPML notebook
 sequence. The stable local verification subset covers notebooks that do not
 need credentials, proprietary/cloud solver access, local solver binaries, or
 long benchmark runs.
+
+The Python notebooks are introductory on-ramps, maintained for correctness and
+for the shared structural contracts, but not for section-by-section parity
+with their Julia counterparts. See
+[Notebook families](CONTRIBUTING.md#notebook-families).
 
 Notebook 6 has Julia and Python variants. The Julia notebook uses the
 supported QCIOpt.jl QUBO workflow and explicitly maps the continuous or

--- a/tests/test_notebook_structure.py
+++ b/tests/test_notebook_structure.py
@@ -293,7 +293,7 @@ class JupyterBookConfigurationTests(unittest.TestCase):
         documents = [(path, path.parent, notebook_markdown(path)) for path in notebook_paths()]
         documents += [
             (REPO_ROOT / name, REPO_ROOT, (REPO_ROOT / name).read_text(encoding="utf-8"))
-            for name in ("index.md", "local-setup.md", "README.md")
+            for name in ("index.md", "local-setup.md", "README.md", "CONTRIBUTING.md")
             if (REPO_ROOT / name).is_file()
         ]
 


### PR DESCRIPTION
## Summary

Adds `CONTRIBUTING.md`, which records the editorial contracts this repository
has been operating under without ever writing them down. Documentation only:
no notebook, workflow, or dependency changes.

This is the first of the four follow-ups from #128, and the one the others
depend on. It resolves #132 in full and satisfies the first acceptance
criterion of #130.

## What the policy says

**The Python notebooks are on-ramps, not mirrors.** They are maintained for
correctness and for the shared structural contracts, but not for
section-by-section parity with their Julia counterparts. Parity that is
implied but never enforced is what produced the heading drift fixed in #128
(`## Random-instance benchmark` against `## Example 2`, `(SA)` against
`(S.A.)`); notebooks 7-11 already have no Python counterpart, so this makes
the existing asymmetry the stated rule.

**Ten structural contracts still bind every notebook.** The list is derived
from `tests/test_notebook_structure.py`, not from prose, so it matches what is
actually enforced. #132 named five of them; the enforced set also covers the
footer selection rule, in-page anchor uniqueness, relative links, Colab route
coverage, and the three-exercise checkpoint rule. Portable kernel metadata is
listed separately because it binds the Python family alone.

**The table of contents keeps presenting each pair as equals.** Labelling the
Python entry as secondary in the navigation would misrepresent the paired
pedagogy and read as "unmaintained" — the outcome #132 explicitly wanted to
avoid. The asymmetry a reader needs is already structural: notebooks 7-11 sit
under their own Julia section, and `index.md`'s map marks the missing Python
counterparts.

**Stored-output budgets.** 256 KB per code cell, 1.0 MB per notebook, 10 MB
across the collection, measured as the serialized `outputs` array rather than
file size. Clearing outputs is explicitly not an acceptable way to shrink a
notebook, since the book build never executes one.

The thresholds were chosen against the measured distribution on `main`
(8.04 MB of the 9.04 MB artifact is stored output), so the exception list is
small and each entry is a concrete target for #130's reduction work:

| Threshold | Over budget today |
| --- | --- |
| 256 KB per cell | 4 cells (551, 400, 299, 274 KB) |
| 1.0 MB per notebook | 3 notebooks (2.22, 1.35, 1.16 MB) |
| 10 MB total | none (8.04 MB) |

## Test change

`test_relative_links_point_at_files_that_exist` now also reads
`CONTRIBUTING.md`, so the new document's relative links are checked like the
other top-level docs. Verified by mutation: adding a broken link to
`CONTRIBUTING.md` turns the test red with
`['CONTRIBUTING.md -> does-not-exist.md']`, and removing it turns it green
again.

No test pins the policy wording. Per the repository's own test-design rule,
documentation wording is not a contract worth pinning; the budget *check* is
#130 follow-up work, not this PR.

## Acceptance criteria

### #132 — resolved in full

- [x] State the policy somewhere durable — `CONTRIBUTING.md`, linked from the
      README intro and from the Notebooks section.
- [x] Decide whether the table of contents should signal the asymmetry — it
      should not; the decision and its rationale are recorded in the policy.
- [x] Review #131 against this decision — posted as a comment on #131. Short
      version: #131 survives at full scope. The reduced contract drops
      structural parity, not correctness, and credential-free execution
      coverage is a correctness commitment.
- [x] Confirm which contracts still bind both families — the ten-row table,
      derived from the test module.

### #130 — one of four criteria

- [x] A documented output-retention and size policy exists.
- [ ] The largest notebooks are reduced where this can be done without losing
      pedagogical information.
- [ ] CI detects accidental large output growth while allowing reviewed
      exceptions.
- [x] The strict book build and notebook-output reproducibility tests continue
      to pass.

**Merging this PR will leave #130 open**, which is why it is linked with
`Refs` rather than `Closes`. The two unchecked criteria are the mechanical half
— measurement script, CI size check, and the actual output reduction — and are
deliberately a separate PR: that work rewrites notebook JSON in the same files
#131 will edit, so it wants its own reviewable diff. #130 closes when that PR
lands.

One consequence of the split worth naming: until the CI check exists, the
budgets in `CONTRIBUTING.md` are a contract nothing enforces. A re-execution
can exceed them and no lane will report it.

## Validation

- `make test` — pass (repository link-policy greps, run against the tracked tree).
- `make test-python` — 121 tests, pass. Also run through the repo-local
  `.venv/bin/python` (3.12.12).
- `make check-notebook-output-hygiene` — pass.
- `make build-book` — strict build, exit 0, no new warnings. `CONTRIBUTING.md`
  is intentionally outside the `myst.yml` table of contents: it is
  contributor-facing, not part of the published book, and the strict build
  confirms it is not picked up as an orphan page.

## Branch hygiene

Base `main`, branched from `cf73717` (the #128 merge). Not stacked; no
prerequisite PRs. No other open PRs touch these files — there are no other
open PRs.

Closes #132
Refs #130, #131, #128
