### PR TITLE
Consolidate the legacy Julia setup appendices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ the repository link policy, not these contracts.
 | Heading hierarchy | No heading level is skipped outside fenced code blocks, so the rendered page has a navigable section tree. |
 | Unindented raw HTML | Every line of a raw-HTML markdown block starts at column zero. A four-space indent publishes the tags as literal source in engines without CommonMark HTML blocks. |
 | Hidden installation cells | Installation, bootstrap, and `versioninfo()` code cells, and any install-titled section outside `## Setup`, carry both the `hide-cell` and `installation` tags. |
+| Setup never follows Summary | Each notebook has exactly one `## Summary`, and no level-2 through level-6 heading whose text contains an install, setup, or validation term appears after it. Setup belongs in the canonical section at the top; tagging a trailing appendix `hide-cell` hides it from the book but leaves the duplication in the source. |
 | Exercise checkpoints | At least three cells marked `# EXERCISE` and three marked with the exact string `# SOLUTION (hidden in workshop version):` — the short `# SOLUTION` form is not counted. The first three solution cells carry the `hide-cell` and `solution` tags; every solution cell must contain real code, not only comments. |
 | Footer structure | Acknowledgments sections and back-to-top links are selected structurally, by heading and in-page anchor, rather than by prose phrase. |
 | In-page anchors | Anchor identifiers are unique across the whole project, and every `#`-link resolves inside its own notebook. |

--- a/local-setup.md
+++ b/local-setup.md
@@ -21,6 +21,10 @@ bootstrap selects the focused project under
 `notebooks_jl/environments/<notebook-key>` instead, so no manual installation
 step is needed there.
 
+To report the version you are actually running, start Julia and call
+`versioninfo()`. Instantiating against an incompatible release fails at the
+notebook's setup cell, so this is a diagnostic rather than a required step.
+
 ## Build the book
 
 From the repository root, install the locked documentation environment and
@@ -61,9 +65,11 @@ because their NetworkX constraints conflict.
 
 ## Commercial solvers
 
-The Julia mathematical-programming notebook has optional sections that use
-commercial solvers. Neither solver is required for the core examples, and
-neither is installed by the notebook project.
+No notebook in this collection calls a commercial solver, and neither solver
+below is a dependency of any notebook project. They are documented here because
+the notebooks are a starting point for your own models, where an LP/MIP or
+MINLP licence is often worth having. The Julia notebooks solve their examples
+with GLPK, Cbc, Ipopt, Bonmin, and Couenne, all open source.
 
 **Gurobi** is one of the most powerful LP and MIP solvers available today, and
 free academic licences are offered. Visit

--- a/local-setup.md
+++ b/local-setup.md
@@ -68,8 +68,9 @@ because their NetworkX constraints conflict.
 No notebook in this collection calls a commercial solver, and neither solver
 below is a dependency of any notebook project. They are documented here because
 the notebooks are a starting point for your own models, where an LP/MIP or
-MINLP licence is often worth having. The Julia notebooks solve their examples
-with GLPK, Cbc, Ipopt, Bonmin, and Couenne, all open source.
+MINLP licence is often worth having. The mathematical-programming notebook,
+the one where a commercial solver would otherwise be expected, solves its
+examples with GLPK, Cbc, Ipopt, Bonmin, and Couenne, all open source.
 
 **Gurobi** is one of the most powerful LP and MIP solvers available today, and
 free academic licences are offered. Visit

--- a/local-setup.md
+++ b/local-setup.md
@@ -3,6 +3,24 @@
 This repository uses `uv` for the Python environment and focused Julia
 projects under `notebooks_jl/environments/`.
 
+## Install Julia
+
+If you do not have a Julia installation yet, consider using
+[juliaup](https://github.com/JuliaLang/juliaup), which installs Julia and keeps
+several versions side by side. The Julia notebook projects carry locks for
+Julia 1.10.11 and Julia 1.12.6.
+
+Instantiate the notebook project once from the repository root:
+
+```bash
+julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'
+```
+
+Each Julia notebook activates that project when it runs locally. In Colab the
+bootstrap selects the focused project under
+`notebooks_jl/environments/<notebook-key>` instead, so no manual installation
+step is needed there.
+
 ## Build the book
 
 From the repository root, install the locked documentation environment and
@@ -40,6 +58,26 @@ Additional targets and environment details are listed in the repository
 particular, Julia notebooks activate their own focused projects, and the Python
 QCI notebook uses a separate dependency environment from the D-Wave notebooks
 because their NetworkX constraints conflict.
+
+## Commercial solvers
+
+The Julia mathematical-programming notebook has optional sections that use
+commercial solvers. Neither solver is required for the core examples, and
+neither is installed by the notebook project.
+
+**Gurobi** is one of the most powerful LP and MIP solvers available today, and
+free academic licences are offered. Visit
+[the Gurobi website](https://www.gurobi.com/), create an account, preferably
+with an academic email address, and obtain a licence. You can then download and
+use the software.
+
+**BARON** is one of the most powerful MINLP solvers available today. Students
+from the University System of Georgia and CMU and UIUC affiliates are eligible
+for a free licence. Visit [the BARON website](https://www.minlp.com/home),
+create an account with an academic email address, and obtain a licence. You can
+then download and use the software.
+
+## Credentials
 
 Cloud execution is always explicit. Provide credentials only through the
 process environment or an approved secret store. QCI submission requires

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -37,7 +37,7 @@
     "julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
     "```\n",
     "\n",
-    "See [local-setup.md](../local-setup.md) for installing Julia itself, the optional commercial solver licences, and the full local workflow.\n",
+    "See [local-setup.md](../local-setup.md) for installing Julia itself and for the full local workflow.\n",
     "\n",
     "**GLPK (required for ILP sections):**\n",
     "- macOS: `brew install glpk`\n",
@@ -172,7 +172,7 @@
     "\n",
     "**Mathematical background:** Basic algebra, inequalities, objective functions, and familiarity with continuous and integer variables.  \n",
     "**Prior notebooks:** None; this is the first Julia notebook in the sequence.  \n",
-    "**Accounts required:** None for the core examples; commercial solver sections require separate solver licenses.  \n",
+    "**Accounts required:** None. Every solver this notebook uses is open source.  \n",
     "**Julia version:** Julia 1.10+ with the JuMP project environment used by this repository.\n"
    ]
   },

--- a/notebooks_jl/1-MathProg.ipynb
+++ b/notebooks_jl/1-MathProg.ipynb
@@ -37,7 +37,7 @@
     "julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
     "```\n",
     "\n",
-    "Run the command from the repository root before opening the Julia notebook locally.\n",
+    "See [local-setup.md](../local-setup.md) for installing Julia itself, the optional commercial solver licences, and the full local workflow.\n",
     "\n",
     "**GLPK (required for ILP sections):**\n",
     "- macOS: `brew install glpk`\n",
@@ -2057,114 +2057,6 @@
     "\n",
     "- [Julia Colab Notebook Template](https://colab.research.google.com/github/ageron/julia_notebooks/blob/master/Julia_Colab_Notebook_Template.ipynb)\n",
     "- [QuIPML22](https://github.com/bernalde/QuIPML22/)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Local Installation Instructions\n",
-    "\n",
-    "If you don't have a Julia installation yet, consider using [juliaup](https://github.com/JuliaLang/juliaup).\n",
-    "Otherwise, run the next cell to install the necessary packages."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "### Validate Julia Installation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-10T17:50:02.805000Z",
-     "iopub.status.busy": "2026-07-10T17:50:02.805000Z",
-     "iopub.status.idle": "2026-07-10T17:50:03.430000Z",
-     "shell.execute_reply": "2026-07-10T17:50:03.430000Z"
-    },
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Julia Version 1.10.11\n",
-      "Commit a2b11907d7b (2026-03-09 14:59 UTC)\n",
-      "Build Info:\n",
-      "  Official https://julialang.org/ release\n",
-      "Platform Info:\n",
-      "  OS: Linux (x86_64-linux-gnu)\n",
-      "  CPU: 36 × Intel(R) Xeon(R) w5-2565X\n",
-      "  WORD_SIZE: 64\n",
-      "  LIBM: libopenlibm\n",
-      "  LLVM: libLLVM-15.0.7 (ORCJIT, sapphirerapids)\n",
-      "Threads: 1 default, 0 interactive, 1 GC (on 36 virtual cores)\n",
-      "Environment:\n",
-      "  JULIA_DEPOT_PATH = <repository>/.julia-depot:<user-julia-depot>\n",
-      "  JULIA_PKG_PRECOMPILE_AUTO = 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "versioninfo()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "### Install Julia Packages"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Installing powerful commercial solvers\n",
-    "\n",
-    "### Gurobi\n",
-    "\n",
-    "Gurobi is one of the most powerful LP and MIP solvers available today.\n",
-    "They provide free academic licenses.\n",
-    "In order to install the software, visit their **[Website](https://www.gurobi.com/)**, create an account (preferably with your academic email), and obtain a license.\n",
-    "Once you do that, you can download and use the software.\n",
-    "\n",
-    "### BARON\n",
-    "\n",
-    "BARON is one of the most powerful MINLP solvers available today.\n",
-    "Students from the University System of Georgia or CMU and UIUC affiliates are eligible for a free license. \n",
-    "In order to install the software, visit their **[Website](https://www.minlp.com/home)**, create an account (with your academic email), and obtain a license.\n",
-    "Once you do that you can download and use the software."
    ]
   },
   {

--- a/notebooks_jl/2-QUBO.ipynb
+++ b/notebooks_jl/2-QUBO.ipynb
@@ -38,7 +38,7 @@
     "julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
     "```\n",
     "\n",
-    "Run the command from the repository root before opening the Julia notebook locally.\n",
+    "See [local-setup.md](../local-setup.md) for installing Julia itself and the full local workflow.\n",
     "\n",
     "**GLPK (required for ILP sections):**\n",
     "- macOS: `brew install glpk`\n",
@@ -2698,85 +2698,6 @@
     "\n",
     "- [Julia Colab Notebook Template](https://colab.research.google.com/github/ageron/julia_notebooks/blob/master/Julia_Colab_Notebook_Template.ipynb)\n",
     "- [QuIPML22](https://github.com/bernalde/QuIPML22/)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "v6UbzyQh3n5q",
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Validate Installation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-07-10T22:05:05.736000Z",
-     "iopub.status.busy": "2026-07-10T22:05:05.736000Z",
-     "iopub.status.idle": "2026-07-10T22:05:06.256000Z",
-     "shell.execute_reply": "2026-07-10T22:05:06.256000Z"
-    },
-    "id": "Ov_tkW6u3n5q",
-    "outputId": "9c5391a5-0890-43c5-d05f-998e915fcc5b",
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Julia Version 1.10.11\n",
-      "Commit a2b11907d7b (2026-03-09 14:59 UTC)\n",
-      "Build Info:\n",
-      "  Official https://julialang.org/ release\n",
-      "Platform Info:\n",
-      "  OS: Linux (x86_64-linux-gnu)\n",
-      "  CPU: 36 × Intel(R) Xeon(R) w5-2565X\n",
-      "  WORD_SIZE: 64\n",
-      "  LIBM: libopenlibm\n",
-      "  LLVM: libLLVM-15.0.7 (ORCJIT, sapphirerapids)\n",
-      "Threads: 1 default, 0 interactive, 1 GC (on 36 virtual cores)\n",
-      "Environment:\n",
-      "  JULIA_DEPOT_PATH = <repository>/.julia-depot:<user-julia-depot>\n",
-      "  JULIA_PKG_PRECOMPILE_AUTO = 0\n",
-      "  JULIA_CONDAPKG_BACKEND = Null\n",
-      "  JULIA_PYTHONCALL_EXE = <repository>/.venv/bin/python3\n"
-     ]
-    }
-   ],
-   "source": [
-    "versioninfo()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BvPIx8Et3n5q",
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Local Installation Instructions\n",
-    "\n",
-    "If you don't have a Julia installation yet, consider using [juliaup](https://github.com/JuliaLang/juliaup).\n",
-    "Otherwise, run the next cell to install the necessary packages.\n",
-    "\n",
-    "### Install Julia Packages"
    ]
   },
   {

--- a/notebooks_jl/3-GAMA.ipynb
+++ b/notebooks_jl/3-GAMA.ipynb
@@ -37,7 +37,7 @@
     "julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
     "```\n",
     "\n",
-    "Run the command from the repository root before opening the Julia notebook locally.\n"
+    "See [local-setup.md](../local-setup.md) for installing Julia itself and the full local workflow.\n"
    ]
   },
   {
@@ -1731,66 +1731,6 @@
     "## References\n",
     "\n",
     "- [QuIPML22](https://github.com/bernalde/QuIPML22/)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "### Local Installation Instructions\n",
-    "\n",
-    "To run the code locally install Julia. Consider using [juliaup](https://github.com/JuliaLang/juliaup)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-10T17:51:59.087000Z",
-     "iopub.status.busy": "2026-07-10T17:51:59.087000Z",
-     "iopub.status.idle": "2026-07-10T17:51:59.651000Z",
-     "shell.execute_reply": "2026-07-10T17:51:59.651000Z"
-    },
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Julia Version 1.10.11\n",
-      "Commit a2b11907d7b (2026-03-09 14:59 UTC)\n",
-      "Build Info:\n",
-      "  Official https://julialang.org/ release\n",
-      "Platform Info:\n",
-      "  OS: Linux (x86_64-linux-gnu)\n",
-      "  CPU: 36 × Intel(R) Xeon(R) w5-2565X\n",
-      "  WORD_SIZE: 64\n",
-      "  LIBM: libopenlibm\n",
-      "  LLVM: libLLVM-15.0.7 (ORCJIT, sapphirerapids)\n",
-      "Threads: 1 default, 0 interactive, 1 GC (on 36 virtual cores)\n",
-      "Environment:\n",
-      "  JULIA_DEPOT_PATH = <repository>/.julia-depot:<user-julia-depot>\n",
-      "  JULIA_PKG_PRECOMPILE_AUTO = 0\n",
-      "  JULIA_CONDAPKG_BACKEND = Null\n",
-      "  JULIA_PYTHONCALL_EXE = <repository>/.venv/bin/python3\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Validate Installation\n",
-    "\n",
-    "versioninfo()"
    ]
   },
   {

--- a/notebooks_jl/4-DWave.ipynb
+++ b/notebooks_jl/4-DWave.ipynb
@@ -37,7 +37,7 @@
     "julia --project=notebooks_jl -e 'using Pkg; Pkg.instantiate()'\n",
     "```\n",
     "\n",
-    "Run the command from the repository root before opening the Julia notebook locally.\n"
+    "See [local-setup.md](../local-setup.md) for installing Julia itself and the full local workflow.\n"
    ]
   },
   {
@@ -1151,76 +1151,6 @@
     "\n",
     "- [Julia Colab Notebook Template](https://colab.research.google.com/github/ageron/julia_notebooks/blob/master/Julia_Colab_Notebook_Template.ipynb)\n",
     "- [QuIPML22](https://github.com/bernalde/QuIPML22/)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Validate Installation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-10T17:52:47.865000Z",
-     "iopub.status.busy": "2026-07-10T17:52:47.865000Z",
-     "iopub.status.idle": "2026-07-10T17:52:48.367000Z",
-     "shell.execute_reply": "2026-07-10T17:52:48.367000Z"
-    },
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Julia Version 1.10.11\n",
-      "Commit a2b11907d7b (2026-03-09 14:59 UTC)\n",
-      "Build Info:\n",
-      "  Official https://julialang.org/ release\n",
-      "Platform Info:\n",
-      "  OS: Linux (x86_64-linux-gnu)\n",
-      "  CPU: 36 × Intel(R) Xeon(R) w5-2565X\n",
-      "  WORD_SIZE: 64\n",
-      "  LIBM: libopenlibm\n",
-      "  LLVM: libLLVM-15.0.7 (ORCJIT, sapphirerapids)\n",
-      "Threads: 1 default, 0 interactive, 1 GC (on 36 virtual cores)\n",
-      "Environment:\n",
-      "  JULIA_DEPOT_PATH = <LOCAL_JULIA_DEPOT>:<JULIA_DEPOT>\n",
-      "  JULIA_PKG_PRECOMPILE_AUTO = 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "versioninfo()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "## Local Installation Instructions\n",
-    "\n",
-    "If you don't have a Julia installation yet, consider using [juliaup](https://github.com/JuliaLang/juliaup).\n",
-    "Otherwise, run the next cell to install the necessary packages.\n",
-    "\n",
-    "### Install Julia Packages"
    ]
   },
   {

--- a/notebooks_py/1-MathProg_python.ipynb
+++ b/notebooks_py/1-MathProg_python.ipynb
@@ -38,6 +38,7 @@
     "```\n",
     "\n",
     "GLPK and CBC are used for LP/MILP sections; IPOPT, BONMIN, and Couenne are used for nonlinear sections when available.\n",
+    "\nSee [local-setup.md](../local-setup.md) for the full local workflow, including optional commercial solver licences.\n",
     "\n",
     "**GLPK (required for ILP sections):**\n",
     "- macOS: `brew install glpk`\n",
@@ -67,7 +68,7 @@
     "\n",
     "**Mathematical background:** Basic algebra, inequalities, objective functions, and familiarity with continuous and integer variables.  \n",
     "**Prior notebooks:** None; this is the first Python notebook in the sequence.  \n",
-    "**Accounts required:** None for the core examples; commercial solver sections require separate solver licenses.  \n",
+    "**Accounts required:** None. Every solver this notebook uses is open source.  \n",
     "**Python version:** Python 3.9+ with the Pyomo stack used by this repository.\n"
    ]
   },
@@ -1499,24 +1500,6 @@
    "metadata": {},
    "source": [
     "We can solve nonconvex MINLP problems, but their complexity creates substantial computational challenges."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide-cell",
-     "installation"
-    ]
-   },
-   "source": [
-    "### Powerful commercial solver installation\n",
-    "\n",
-    "#### Gurobi Installation\n",
-    "Gurobi is one of the most powerful LP and MIP solvers available today. They provide free academic licenses. To install the software, visit their **[website](https://www.gurobi.com/)**, create an account, and obtain a license. Once you do that, you can download and use the software.\n",
-    "\n",
-    "#### BARON Installation\n",
-    "BARON is one of the most powerful MINLP solvers available today. To install the software, visit their **[website](https://www.minlp.com/home)**, create an account, and obtain a license. Once you do that, you can download and use the software."
    ]
   },
   {

--- a/tests/test_notebook_structure.py
+++ b/tests/test_notebook_structure.py
@@ -334,6 +334,42 @@ class JupyterBookConfigurationTests(unittest.TestCase):
 
 
 class NotebookPedagogyCellTests(unittest.TestCase):
+    def test_setup_material_never_follows_the_summary(self) -> None:
+        """Setup belongs in one place, at the top, not in a trailing appendix.
+
+        Defect class: a notebook regrows a late installation or validation
+        appendix, so the raw notebook ends in setup material instead of
+        Summary, References, and Acknowledgments. Tagging such a cell
+        ``hide-cell`` hides it from the rendered book, which is what makes the
+        duplication invisible to every other check here.
+        """
+        setup_heading = re.compile(
+            r"^#{2,6}\s+.*\b(install\w*|setup|validat\w*)\b", re.IGNORECASE | re.MULTILINE
+        )
+        offenders = []
+
+        for path in notebook_paths():
+            cells = notebook_cells(path)
+            summaries = [
+                index
+                for index, cell in enumerate(cells)
+                if cell.get("cell_type") == "markdown"
+                and notebook_first_heading(cell) == "## Summary"
+            ]
+
+            with self.subTest(notebook=path.relative_to(REPO_ROOT).as_posix()):
+                self.assertEqual(1, len(summaries))
+
+            for cell in cells[summaries[-1] + 1 :]:
+                if cell.get("cell_type") != "markdown":
+                    continue
+                match = setup_heading.search("".join(cell.get("source", [])))
+                if match:
+                    relative_path = path.relative_to(REPO_ROOT).as_posix()
+                    offenders.append(f"{relative_path}: {match.group(0)!r}")
+
+        self.assertEqual([], offenders)
+
     def test_installation_cells_are_hidden_in_the_book(self) -> None:
         installation_markers = (
             "!pip install",


### PR DESCRIPTION
## Summary

Removes the legacy setup appendices from the four older Julia notebooks, moves
the guidance that was genuinely unique into `local-setup.md`, and adds the
regression guard that keeps them from regrowing.

This is the residual source-side work from #51. #128 tagged those cells as
hidden installation content, which fixed the rendered book without moving
cells; the raw notebooks still ended in setup material.

## What was removed

All removed cells sat between `## References` and `## Acknowledgments`, and all
were already tagged `hide-cell` + `installation`:

| Notebook | Cells removed |
| --- | --- |
| `notebooks_jl/1-MathProg.ipynb` | Local installation, Validate Julia Installation, `versioninfo()`, empty Install Julia Packages, commercial solvers |
| `notebooks_jl/2-QUBO.ipynb` | Validate Installation, `versioninfo()`, Local installation |
| `notebooks_jl/3-GAMA.ipynb` | Local installation, `versioninfo()` |
| `notebooks_jl/4-DWave.ipynb` | Validate Installation, `versioninfo()`, Local installation |

They duplicated the canonical `## Setup` section at the top of each notebook,
and their shared instruction — "run the next cell to install the necessary
packages" — had become false. The install cell moved to the top in an earlier
pass, so the next cell is `## Acknowledgments`.

## What was preserved

Into [local-setup.md](local-setup.md), so it has one canonical location:

- **Install Julia** — the juliaup pointer from the appendices, plus the locked
  Julia versions (1.10.11 and 1.12.6, verified against the committed manifests)
  and the distinction between the local project and the focused Colab project.
- **Commercial solvers** — the Gurobi and BARON licence notes from
  `1-MathProg`, kept close to their original wording. These were the only
  genuinely unique content in any appendix. Documented explicitly as reference
  material for readers extending the notebooks: no notebook in either family
  calls Gurobi or BARON, and neither is declared in any notebook project. The
  same pass corrected the `1-MathProg` Prerequisites line, which promised
  licences for commercial-solver sections the notebook does not contain.

Each notebook's `## Setup` cell now links to `local-setup.md` in place of a
sentence that restated the line directly above it ("Run the following from the
repository root…" followed by "Run the command from the repository root…").

## No re-execution was needed

Each removed code cell held the **highest** execution count in its notebook
(39, 42, 32, 25 respectively), so removing them leaves the remaining counts
contiguous from 1 with no gaps, and no stored output changed:

| Notebook | Removed count | Remaining |
| --- | --- | --- |
| `1-MathProg` | 39 | 1–38, contiguous |
| `2-QUBO` | 42 | 1–41, contiguous |
| `3-GAMA` | 32 | 1–31, contiguous |
| `4-DWave` | 25 | 1–24, contiguous |

The notebooks were edited by round-tripping each file's own JSON serialization
(detected per file as `indent=1, ensure_ascii=False` with a trailing newline),
so the diff is 4 changed source lines plus the removed cells rather than a
whole-file rewrite.

## New regression guard

`test_setup_material_never_follows_the_summary` asserts each notebook has
exactly one `## Summary` and that no install, setup, or validation heading
follows it.

Note that this binds **all 17 notebooks**, not only the four this issue names.
The appendix check is what #129 asks for; the one-`## Summary` assertion is a
deliberate widening, since a notebook silently losing its Summary is exactly the
kind of regression the repository's test-design rule says to guard, and every
notebook already satisfies it. Called out here because it is a new repository-wide
contract arriving in an issue-scoped PR.

This closes a real hole rather than restating the change. The existing
`test_installation_cells_are_hidden_in_the_book` only requires such cells to be
*tagged* — and tagging them `hide-cell` is precisely what hid the duplication
from the rendered book and therefore from every other check. Verified by
mutation: reintroducing the exact appendix this PR removes, tagged hidden as it
was, turns the test red with
`["notebooks_jl/3-GAMA.ipynb: '### Local Installation'"]`; restoring turns it
green.

## Acceptance criteria

- [x] The four notebooks have no setup or installation sections after Summary.
      Verified across all 17 notebooks, not only the four: the Python family
      never had the pattern, so nothing was left behind.
- [x] Local setup guidance has one canonical location and remains usable
      outside Colab — `local-setup.md`, linked from each Setup cell. This now
      covers the Python sibling too: `1-MathProg_python` carried a second copy
      of the Gurobi/BARON guidance in a hidden cell *before* `## Summary`, which
      the appendix guard could not see. No commercial-solver guidance remains in
      any notebook.
- [x] `make test` and `make build-book` pass.
- [x] Raw notebooks still open and run in order — execution counts stay
      contiguous, so cell order is unchanged for a fresh run.

## Validation

- `make test` — pass.
- `make test-python` — 122 tests, pass (`.venv/bin/python` 3.12.12). 121 before
  this PR, plus the new guard.
- `make check-notebook-output-hygiene` — pass.
- `make build-book` — strict, exit 0. The new `../local-setup.md` links from the
  notebooks were checked in the built output, not just at source level: the
  page data resolves them to internal `/local-setup` with `internal: true` and
  no error. The only links flagged on those pages are pre-existing external
  GitHub URLs, which `myst.yml` deliberately treats as `warn`.

## Coordination

#133 merged into `main` at `ae15736`, so this branch is the one that merges
second and the promised handoff is now discharged here rather than deferred.
Current `main` is merged in, and `CONTRIBUTING.md` gains the contract row for
the invariant this PR establishes and enforces:

> **Setup never follows Summary** — Each notebook has exactly one `## Summary`,
> and no level-2 through level-6 heading whose text contains an install, setup,
> or validation term appears after it.

No coordination items remain open.

## Branch hygiene

Base `main`, branched from `cf73717`, with current `main` (`ae15736`, the #133
merge) merged in append-only. The one overlapping file,
`tests/test_notebook_structure.py`, auto-merged: #133 added `CONTRIBUTING.md` to
the relative-link list while this branch added the appendix guard. Not stacked;
no prerequisite PRs.

Closes #129
Refs #51, #128, #133


