### PR TITLE
Enforce the committed notebook output budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Notebook output hygiene
         run: make check-notebook-output-hygiene
 
+      - name: Notebook output budgets
+        run: make check-notebook-output-budgets
+
       - name: Python unit tests
         run: make test-python PYTHON="uv run --locked --group docs python"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,27 +99,46 @@ change to the lesson. These budgets bound that drift:
 | One notebook | 1.0 MB of stored output |
 | All notebooks | 10 MB of stored output |
 
-Measure stored output as the serialized `outputs` array of every code cell,
-not the notebook's file size.
+Measure stored output as the serialized `outputs` array of every code cell, not
+the notebook's file size: the UTF-8 length of that array as compact JSON, which
+is what `make check-notebook-output-budgets` reports. `KB` is 1024 bytes and
+`MB` is 1024 KB throughout this section.
+
+`make check-notebook-output-budgets` reads the budgets and the exceptions below
+out of this file, so these tables are the enforced policy rather than a
+description of one. It runs in CI, and
+`tests/test_notebook_output_budgets.py` asserts the same contract under
+`make test-python`.
 
 ### Documented exceptions
 
-These exceed a budget by deliberate grant rather than by accident:
+These exceed a budget by deliberate grant rather than by accident. A grant is a
+ceiling, not a waiver: the scope still has a limit, and passing it needs review
+in the same way passing the budget does. Each ceiling was set at the size the
+grant was written against plus roughly ten percent, rounded up to the next
+32 KB, so an ordinary re-render fits and a new or duplicated figure does not.
 
-| Notebook or cell | Budget exceeded | What the stored output is |
-| --- | --- | --- |
-| `notebooks_py/5-Benchmarking_python.ipynb` | notebook, and one cell | A `nx.draw` spring-layout rendering of the random Ising model graph |
-| `notebooks_jl/5-Benchmarking.ipynb` | notebook, and one cell | A circular-layout plot of the same Ising graph |
-| `notebooks_py/4-DWAVE_python.ipynb` | two cells | The QPU topology graph and the minor-embedding graph |
-| `notebooks_py/1-MathProg_python.ipynb` | notebook | Nine stored plots holding 1.14 MB of the notebook's 1.16 MB. Eight are near-identical redraws of the same feasible region, each adding one annotation for the LP, ILP, convex INLP, and nonconvex INLP solutions; the ninth is an unrelated complexity-growth plot |
+| Notebook | Scope | Granted ceiling | What the stored output is |
+| --- | --- | --- | --- |
+| `notebooks_py/5-Benchmarking_python.ipynb` | One notebook | 2400 KB | The graph render below, plus the sweep and time-to-solution figures of the simulated-annealing benchmark |
+| `notebooks_py/5-Benchmarking_python.ipynb` | One code cell | 608 KB | A `nx.draw` spring-layout rendering of the random Ising model graph |
+| `notebooks_jl/5-Benchmarking.ipynb` | One notebook | 1472 KB | The plot below, a system-layout plot of the same model, and the schedule, total-runtime, and ensemble figures |
+| `notebooks_jl/5-Benchmarking.ipynb` | One code cell | 320 KB | A circular-layout plot of the same Ising graph |
+| `notebooks_py/4-DWAVE_python.ipynb` | One code cell | 448 KB | The QPU topology graph, and the minor-embedding graph a few cells later |
+| `notebooks_py/1-MathProg_python.ipynb` | One notebook | 1248 KB | Nine stored plots, holding nearly all of this notebook's output. Eight are near-identical redraws of the same feasible region, each adding one annotation for the LP, ILP, convex INLP, and nonconvex INLP solutions; the ninth is an unrelated complexity-growth plot |
 
 Two different failures are visible in that table, and they need different
-remedies. Every cell over the per-cell budget is a dense graph-layout render,
+remedies. Every cell holding a per-cell grant is a dense graph-layout render,
 where the lever is rasterization and resolution rather than fewer results.
 `1-MathProg_python` is the opposite case: no single cell is close to the
 per-cell budget, and the notebook is over only because one figure is stored
 eight times over. That duplication is exactly what the per-notebook budget
 exists to catch.
+
+Adding a row is a review decision. Removing one is not: once a reduction brings
+a scope back inside its budget, the check reports the row as no longer needed
+and fails until it is deleted, so the table cannot outlive the exception it
+records.
 
 An exception is a decision to revisit, not a permanent allowance. Reducing a
 grant, by rendering a figure at a lower resolution or in a more compact format
@@ -128,11 +147,12 @@ instruction survives it.
 
 ### Changing outputs
 
-When a change re-executes a notebook, check the resulting stored-output size
-against the budgets above. Growth past a budget needs either a reduction or a
-new documented exception in the table, decided in review rather than merged
-silently. Adding a figure to a notebook that already holds an exception is the
-case most likely to pass unnoticed.
+When a change re-executes a notebook, run
+`make check-notebook-output-budgets` and read the size it reports. Growth past
+a budget needs either a reduction or a new documented exception in the table,
+decided in review rather than merged silently. Adding a figure to a notebook
+that already holds an exception is the case most likely to pass unnoticed,
+which is why every grant carries a ceiling of its own.
 
 Committed outputs must not carry credentials, tokens, or machine-specific
 absolute paths; `make check-notebook-output-hygiene` guards the known personal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,9 @@ exists to catch.
 Adding a row is a review decision. Removing one is not: once a reduction brings
 a scope back inside its budget, the check reports the row as no longer needed
 and fails until it is deleted, so the table cannot outlive the exception it
-records.
+records. Deleting the last row is the intended end state — keep the header and
+separator so the check can still find the table, and every notebook is then held
+to the plain budgets.
 
 An exception is a decision to revisit, not a permanent allowance. Reducing a
 grant, by rendering a figure at a lower resolution or in a more compact format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,11 @@ in the same way passing the budget does. Each ceiling was set at the size the
 grant was written against plus roughly ten percent, rounded up to the next
 32 KB, so an ordinary re-render fits and a new or duplicated figure does not.
 
+A `One code cell` grant raises the per-cell ceiling for *any* one code cell in
+that notebook, not for the particular cell the row describes: cell positions
+shift whenever a cell is added, so there is no stable anchor to grant against.
+The per-notebook budget is what bounds the rest of the notebook.
+
 | Notebook | Scope | Granted ceiling | What the stored output is |
 | --- | --- | --- | --- |
 | `notebooks_py/5-Benchmarking_python.ipynb` | One notebook | 2400 KB | The graph render below, plus the sweep and time-to-solution figures of the simulated-annealing benchmark |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build-book sysimage test-python test-julia test-qciopt-dwave-coexistence check-notebook-output-hygiene clear-notebook-outputs refresh-tcga-aml refresh-julia-notebook-environments verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-qci-julia-local verify-qci-julia-cloud verify-canonical-problems-julia verify-order-partitioning-julia verify-cancer-genomics-julia verify-qaoa-julia-local verify-annealing-julia-local verify-five-starter-problems-julia-local verify-colab-bootstrap-output verify-colab-hosted verify-qaoa-julia-ibm verify-annealing-julia-qpu
+.PHONY: test build-book sysimage test-python test-julia test-qciopt-dwave-coexistence check-notebook-output-hygiene check-notebook-output-budgets clear-notebook-outputs refresh-tcga-aml refresh-julia-notebook-environments verify-notebooks verify-python-portable verify-qubo-python verify-gama-python verify-benchmarking-python verify-qci-julia-local verify-qci-julia-cloud verify-canonical-problems-julia verify-order-partitioning-julia verify-cancer-genomics-julia verify-qaoa-julia-local verify-annealing-julia-local verify-five-starter-problems-julia-local verify-colab-bootstrap-output verify-colab-hosted verify-qaoa-julia-ibm verify-annealing-julia-qpu
 
 PYTHON ?= python3
 UV ?= uv
@@ -57,6 +57,9 @@ check-notebook-output-hygiene:
 		echo "Found stale or personal notebook output paths"; \
 		exit 1; \
 	fi
+
+check-notebook-output-budgets:
+	$(PYTHON) ./scripts/check_notebook_output_budgets.py
 
 clear-notebook-outputs:
 	$(PYTHON) -m jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace $(NOTEBOOK_FILES)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ make test
 make test-python
 make test-julia
 make test-qciopt-dwave-coexistence
+make check-notebook-output-hygiene
+make check-notebook-output-budgets
 make verify-qubo-python
 make verify-gama-python
 make verify-qci-julia-local

--- a/scripts/check_notebook_output_budgets.py
+++ b/scripts/check_notebook_output_budgets.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Check committed notebook output against the budgets in CONTRIBUTING.md.
+
+The budgets and the documented exceptions are read from CONTRIBUTING.md rather
+than restated here, so the policy a contributor reads is the policy this check
+enforces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "CONTRIBUTING.md"
+NOTEBOOK_DIRS = ("notebooks_jl", "notebooks_py")
+BUDGET_HEADING = "### Size budgets"
+EXCEPTION_HEADING = "### Documented exceptions"
+CELL_SCOPE = "One code cell"
+NOTEBOOK_SCOPE = "One notebook"
+COLLECTION_SCOPE = "All notebooks"
+GRANTABLE_SCOPES = (CELL_SCOPE, NOTEBOOK_SCOPE)
+KILOBYTE = 1024
+SIZE_UNITS = {"KB": KILOBYTE, "MB": KILOBYTE * KILOBYTE}
+SIZE_PATTERN = re.compile(r"([0-9]+(?:\.[0-9]+)?)\s*(KB|MB)")
+
+
+def parse_size(text: str) -> int:
+    """Return the byte count of a policy size such as ``256 KB`` or ``1.0 MB``."""
+    match = SIZE_PATTERN.match(text.strip())
+    if match is None:
+        raise ValueError(f"Not a policy size: {text!r}. Use a value such as '256 KB'.")
+    return round(float(match.group(1)) * SIZE_UNITS[match.group(2)])
+
+
+def format_size(size_bytes: int) -> str:
+    if size_bytes >= SIZE_UNITS["MB"]:
+        return f"{size_bytes / SIZE_UNITS['MB']:.2f} MB"
+    return f"{size_bytes / KILOBYTE:.1f} KB"
+
+
+def markdown_table_rows(document: str, heading: str) -> list[dict[str, str]]:
+    """Return the rows of the first Markdown table under ``heading``."""
+    lines = document.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError as exc:
+        raise ValueError(f"{POLICY_PATH.name} has no {heading!r} section.") from exc
+
+    table = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if stripped.startswith("|"):
+            table.append([cell.strip().strip("`") for cell in stripped.strip("|").split("|")])
+        elif table:
+            break
+        elif stripped.startswith("#"):
+            raise ValueError(f"{POLICY_PATH.name} has no table under {heading!r}.")
+
+    if len(table) < 3:
+        raise ValueError(f"The table under {heading!r} has no rows.")
+
+    header, _separator, *body = table
+    return [dict(zip(header, row)) for row in body]
+
+
+@dataclass(frozen=True)
+class Policy:
+    """Budgets by scope name, and the granted ceilings that override them."""
+
+    budgets: dict[str, int]
+    grants: dict[tuple[str, str], int]
+
+    def ceiling(self, notebook: str, scope: str) -> int:
+        return self.grants.get((notebook, scope), self.budgets[scope])
+
+    def is_granted(self, notebook: str, scope: str) -> bool:
+        return (notebook, scope) in self.grants
+
+
+def load_policy(document: str) -> Policy:
+    budgets = {
+        row["Scope"]: parse_size(row["Budget"])
+        for row in markdown_table_rows(document, BUDGET_HEADING)
+    }
+    missing = {CELL_SCOPE, NOTEBOOK_SCOPE, COLLECTION_SCOPE} - set(budgets)
+    if missing:
+        raise ValueError(f"The size-budget table is missing scopes: {sorted(missing)}.")
+
+    grants: dict[tuple[str, str], int] = {}
+    for row in markdown_table_rows(document, EXCEPTION_HEADING):
+        scope = row["Scope"]
+        if scope not in GRANTABLE_SCOPES:
+            raise ValueError(
+                f"Exception scope {scope!r} is not one of {list(GRANTABLE_SCOPES)}. "
+                f"The {COLLECTION_SCOPE!r} budget takes no exception."
+            )
+        key = (row["Notebook"], scope)
+        if key in grants:
+            raise ValueError(f"Duplicate exception row for {key[0]} at scope {scope!r}.")
+        grants[key] = parse_size(row["Granted ceiling"])
+
+    return Policy(budgets=budgets, grants=grants)
+
+
+def cell_output_bytes(cell: dict) -> int:
+    """Return the size of one cell's stored output as the policy measures it."""
+    return len(json.dumps(cell.get("outputs", []), ensure_ascii=False).encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class Measurement:
+    notebook: str
+    stored_bytes: int
+    cell_bytes: tuple[tuple[int, int], ...]
+
+    @property
+    def largest_cell(self) -> tuple[int, int]:
+        if not self.cell_bytes:
+            return (-1, 0)
+        return max(self.cell_bytes, key=lambda item: item[1])
+
+
+def measure_notebook(path: Path, name: str | None = None) -> Measurement:
+    notebook = json.loads(path.read_text())
+    cell_bytes = tuple(
+        (index, cell_output_bytes(cell))
+        for index, cell in enumerate(notebook["cells"])
+        if cell.get("cell_type") == "code"
+    )
+    return Measurement(
+        notebook=name if name is not None else path.name,
+        stored_bytes=sum(size for _index, size in cell_bytes),
+        cell_bytes=cell_bytes,
+    )
+
+
+def measure_repository(repo_root: Path = REPO_ROOT) -> list[Measurement]:
+    return [
+        measure_notebook(path, path.relative_to(repo_root).as_posix())
+        for directory in NOTEBOOK_DIRS
+        for path in sorted((repo_root / directory).glob("*.ipynb"))
+    ]
+
+
+def check(policy: Policy, measurements: list[Measurement]) -> list[str]:
+    """Return one message per budget violation, empty when the tree conforms."""
+    measured = {measurement.notebook: measurement for measurement in measurements}
+    violations = []
+
+    for notebook, scope in sorted(policy.grants):
+        ceiling = policy.grants[(notebook, scope)]
+        budget = policy.budgets[scope]
+        if notebook not in measured:
+            violations.append(
+                f"{notebook}: documented exception for {scope!r} names a notebook "
+                f"that does not exist."
+            )
+            continue
+        if ceiling <= budget:
+            violations.append(
+                f"{notebook}: the {scope!r} exception grants {format_size(ceiling)}, "
+                f"which the {format_size(budget)} budget already allows. Remove the row."
+            )
+            continue
+        actual = (
+            measured[notebook].stored_bytes
+            if scope == NOTEBOOK_SCOPE
+            else measured[notebook].largest_cell[1]
+        )
+        if actual <= budget:
+            violations.append(
+                f"{notebook}: the {scope!r} exception is no longer needed — "
+                f"{format_size(actual)} now fits the {format_size(budget)} budget. "
+                f"Remove the row."
+            )
+
+    for measurement in measurements:
+        notebook = measurement.notebook
+        notebook_ceiling = policy.ceiling(notebook, NOTEBOOK_SCOPE)
+        if measurement.stored_bytes > notebook_ceiling:
+            violations.append(
+                f"{notebook}: stores {format_size(measurement.stored_bytes)} of output, "
+                f"over the {format_size(notebook_ceiling)} "
+                f"{'granted ceiling' if policy.is_granted(notebook, NOTEBOOK_SCOPE) else 'budget'}."
+            )
+
+        cell_ceiling = policy.ceiling(notebook, CELL_SCOPE)
+        for index, size in measurement.cell_bytes:
+            if size > cell_ceiling:
+                violations.append(
+                    f"{notebook}: cell {index} stores {format_size(size)} of output, "
+                    f"over the {format_size(cell_ceiling)} "
+                    f"{'granted ceiling' if policy.is_granted(notebook, CELL_SCOPE) else 'budget'}."
+                )
+
+    stored_total = sum(measurement.stored_bytes for measurement in measurements)
+    collection_budget = policy.budgets[COLLECTION_SCOPE]
+    if stored_total > collection_budget:
+        violations.append(
+            f"All notebooks: store {format_size(stored_total)} of output, over the "
+            f"{format_size(collection_budget)} budget. This budget takes no exception."
+        )
+
+    return violations
+
+
+def report(policy: Policy, measurements: list[Measurement]) -> str:
+    lines = [
+        f"{'notebook':44s} {'stored':>10s} {'ceiling':>10s} "
+        f"{'largest cell':>13s} {'ceiling':>10s}",
+    ]
+    for measurement in sorted(measurements, key=lambda item: -item.stored_bytes):
+        notebook = measurement.notebook
+        index, size = measurement.largest_cell
+        lines.append(
+            f"{notebook:44s} {format_size(measurement.stored_bytes):>10s} "
+            f"{format_size(policy.ceiling(notebook, NOTEBOOK_SCOPE)):>10s} "
+            f"{f'#{index}: ' + format_size(size):>13s} "
+            f"{format_size(policy.ceiling(notebook, CELL_SCOPE)):>10s}"
+        )
+
+    stored_total = sum(measurement.stored_bytes for measurement in measurements)
+    lines.append(
+        f"\n{len(measurements)} notebooks store {format_size(stored_total)} of output, "
+        f"against a {format_size(policy.budgets[COLLECTION_SCOPE])} budget."
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    policy = load_policy(POLICY_PATH.read_text())
+    measurements = measure_repository()
+    print(report(policy, measurements))
+
+    violations = check(policy, measurements)
+    if not violations:
+        print("\nEvery notebook is within its documented output budget.")
+        return 0
+
+    print(f"\n{len(violations)} output-budget violation(s):")
+    for violation in violations:
+        print(f"  - {violation}")
+    print(
+        "\nReduce the stored output, or record a reviewed exception in the "
+        f"'{EXCEPTION_HEADING.lstrip('# ')}' table of {POLICY_PATH.name}."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_notebook_output_budgets.py
+++ b/scripts/check_notebook_output_budgets.py
@@ -47,11 +47,16 @@ def markdown_table_rows(
     document: str,
     heading: str,
     required_columns: tuple[str, ...],
+    allow_no_rows: bool = False,
 ) -> list[dict[str, str]]:
     """Return the rows of the first Markdown table under ``heading``.
 
     The policy lives in prose, so every way of breaking the table has to report
     what to fix rather than raise from wherever a value was later read.
+
+    ``allow_no_rows`` covers a table whose empty state is meaningful: the
+    exceptions table is expected to lose its last row once reductions land, so
+    requiring one would force a dummy grant to stay behind.
     """
     lines = document.splitlines()
     try:
@@ -69,10 +74,13 @@ def markdown_table_rows(
         elif stripped.startswith("#"):
             raise ValueError(f"{POLICY_PATH.name} has no table under {heading!r}.")
 
-    if len(table) < 3:
-        raise ValueError(f"The table under {heading!r} has no rows.")
+    if len(table) < 2:
+        raise ValueError(f"{POLICY_PATH.name} has no table under {heading!r}.")
 
     header, _separator, *body = table
+    if not body and not allow_no_rows:
+        raise ValueError(f"The table under {heading!r} has no rows.")
+
     missing = [column for column in required_columns if column not in header]
     if missing:
         raise ValueError(
@@ -116,7 +124,10 @@ def load_policy(document: str) -> Policy:
 
     grants: dict[tuple[str, str], int] = {}
     exception_rows = markdown_table_rows(
-        document, EXCEPTION_HEADING, ("Notebook", "Scope", "Granted ceiling")
+        document,
+        EXCEPTION_HEADING,
+        ("Notebook", "Scope", "Granted ceiling"),
+        allow_no_rows=True,
     )
     for row in exception_rows:
         scope = row["Scope"]
@@ -134,8 +145,17 @@ def load_policy(document: str) -> Policy:
 
 
 def cell_output_bytes(cell: dict) -> int:
-    """Return the size of one cell's stored output as the policy measures it."""
-    return len(json.dumps(cell.get("outputs", []), ensure_ascii=False).encode("utf-8"))
+    """Return the size of one cell's stored output as the policy measures it.
+
+    Compact separators are part of the definition in CONTRIBUTING.md: the
+    default `", "` and `": "` add a byte per delimiter, which measures output the
+    policy does not describe.
+    """
+    return len(
+        json.dumps(
+            cell.get("outputs", []), ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+    )
 
 
 @dataclass(frozen=True)

--- a/scripts/check_notebook_output_budgets.py
+++ b/scripts/check_notebook_output_budgets.py
@@ -43,8 +43,16 @@ def format_size(size_bytes: int) -> str:
     return f"{size_bytes / KILOBYTE:.1f} KB"
 
 
-def markdown_table_rows(document: str, heading: str) -> list[dict[str, str]]:
-    """Return the rows of the first Markdown table under ``heading``."""
+def markdown_table_rows(
+    document: str,
+    heading: str,
+    required_columns: tuple[str, ...],
+) -> list[dict[str, str]]:
+    """Return the rows of the first Markdown table under ``heading``.
+
+    The policy lives in prose, so every way of breaking the table has to report
+    what to fix rather than raise from wherever a value was later read.
+    """
     lines = document.splitlines()
     try:
         start = lines.index(heading)
@@ -65,7 +73,22 @@ def markdown_table_rows(document: str, heading: str) -> list[dict[str, str]]:
         raise ValueError(f"The table under {heading!r} has no rows.")
 
     header, _separator, *body = table
-    return [dict(zip(header, row)) for row in body]
+    missing = [column for column in required_columns if column not in header]
+    if missing:
+        raise ValueError(
+            f"The table under {heading!r} is missing the column(s) {missing} that "
+            f"the check reads. Its columns are {header}."
+        )
+
+    rows = []
+    for row in body:
+        if len(row) != len(header):
+            raise ValueError(
+                f"A row under {heading!r} has {len(row)} cells for {len(header)} "
+                f"columns: {row}."
+            )
+        rows.append(dict(zip(header, row)))
+    return rows
 
 
 @dataclass(frozen=True)
@@ -85,14 +108,17 @@ class Policy:
 def load_policy(document: str) -> Policy:
     budgets = {
         row["Scope"]: parse_size(row["Budget"])
-        for row in markdown_table_rows(document, BUDGET_HEADING)
+        for row in markdown_table_rows(document, BUDGET_HEADING, ("Scope", "Budget"))
     }
     missing = {CELL_SCOPE, NOTEBOOK_SCOPE, COLLECTION_SCOPE} - set(budgets)
     if missing:
         raise ValueError(f"The size-budget table is missing scopes: {sorted(missing)}.")
 
     grants: dict[tuple[str, str], int] = {}
-    for row in markdown_table_rows(document, EXCEPTION_HEADING):
+    exception_rows = markdown_table_rows(
+        document, EXCEPTION_HEADING, ("Notebook", "Scope", "Granted ceiling")
+    )
+    for row in exception_rows:
         scope = row["Scope"]
         if scope not in GRANTABLE_SCOPES:
             raise ValueError(
@@ -125,7 +151,13 @@ class Measurement:
         return max(self.cell_bytes, key=lambda item: item[1])
 
 
-def measure_notebook(path: Path, name: str | None = None) -> Measurement:
+def measure_notebook(path: Path, name: str) -> Measurement:
+    """Measure ``path``, recorded under ``name``.
+
+    The name is required because the exceptions are keyed by repository-relative
+    path: a measurement recorded under a bare filename matches no grant, and the
+    mismatch would surface as a complaint about the policy table.
+    """
     notebook = json.loads(path.read_text())
     cell_bytes = tuple(
         (index, cell_output_bytes(cell))
@@ -133,18 +165,25 @@ def measure_notebook(path: Path, name: str | None = None) -> Measurement:
         if cell.get("cell_type") == "code"
     )
     return Measurement(
-        notebook=name if name is not None else path.name,
+        notebook=name,
         stored_bytes=sum(size for _index, size in cell_bytes),
         cell_bytes=cell_bytes,
     )
 
 
 def measure_repository(repo_root: Path = REPO_ROOT) -> list[Measurement]:
-    return [
+    measurements = [
         measure_notebook(path, path.relative_to(repo_root).as_posix())
         for directory in NOTEBOOK_DIRS
         for path in sorted((repo_root / directory).glob("*.ipynb"))
     ]
+    if not measurements:
+        raise ValueError(
+            f"Found no notebooks in {list(NOTEBOOK_DIRS)} under {repo_root}. The "
+            "budgets cover every published notebook, so an empty set is a "
+            "discovery failure rather than a clean result."
+        )
+    return measurements
 
 
 def check(policy: Policy, measurements: list[Measurement]) -> list[str]:

--- a/tests/test_notebook_output_budgets.py
+++ b/tests/test_notebook_output_budgets.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from notebook_test_support import REPO_ROOT
+from notebook_test_support import REPO_ROOT, notebook_paths
 
 
 BUDGETS_MODULE_PATH = REPO_ROOT / "scripts" / "check_notebook_output_budgets.py"
@@ -154,6 +154,26 @@ class PolicyParsingTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "no table"):
             budgets.load_policy(document)
 
+    def test_names_a_renamed_column_the_check_reads(self) -> None:
+        # Defect class: an edit to the policy table surfaces as a traceback from
+        # wherever a value was read, instead of naming the column to restore.
+        document = policy_document(
+            DEFAULT_BUDGET_ROWS,
+            "| `notebooks_py/2-QUBO_python.ipynb` | One notebook | 2 MB | plots |",
+        ).replace("| Notebook | Scope | Granted ceiling |", "| Notebook | Scope | Ceiling |")
+
+        with self.assertRaisesRegex(ValueError, r"missing the column\(s\).*Granted ceiling"):
+            budgets.load_policy(document)
+
+    def test_rejects_a_row_that_does_not_fill_the_table(self) -> None:
+        document = policy_document(
+            DEFAULT_BUDGET_ROWS,
+            "| `notebooks_py/2-QUBO_python.ipynb` | One notebook | 2 MB |",
+        )
+
+        with self.assertRaisesRegex(ValueError, "3 cells for 4 columns"):
+            budgets.load_policy(document)
+
 
 class MeasurementTests(unittest.TestCase):
     def test_measures_stored_output_as_compact_utf8_json(self) -> None:
@@ -181,7 +201,7 @@ class MeasurementTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "example.ipynb"
             path.write_text(json.dumps(notebook))
-            measured = budgets.measure_notebook(path)
+            measured = budgets.measure_notebook(path, "notebooks_py/example.ipynb")
 
         self.assertEqual([1, 2], [index for index, _size in measured.cell_bytes])
         self.assertEqual(2, measured.cell_bytes[1][1])
@@ -267,15 +287,32 @@ class BudgetViolationTests(unittest.TestCase):
 
 
 class CommittedOutputBudgetTests(unittest.TestCase):
+    def test_the_check_measures_every_published_notebook(self) -> None:
+        # Defect class: a notebook moves out of the two globbed directories and
+        # stops being measured, which the budgets themselves cannot report.
+        measured = {measurement.notebook for measurement in budgets.measure_repository()}
+        published = {
+            path.relative_to(REPO_ROOT).as_posix() for path in notebook_paths()
+        }
+
+        self.assertTrue(published)
+        self.assertEqual(published, measured)
+
+    def test_discovering_no_notebook_is_a_failure_rather_than_a_clean_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            for name in budgets.NOTEBOOK_DIRS:
+                (Path(directory) / name).mkdir()
+
+            with self.assertRaisesRegex(ValueError, "discovery failure"):
+                budgets.measure_repository(Path(directory))
+
     def test_committed_notebooks_are_within_the_documented_budgets(self) -> None:
         # Defect class: a re-executed notebook commits a larger or duplicated
         # figure, which no other check sees because the book build never runs
         # a notebook and every source-level contract still holds.
         loaded = budgets.load_policy(POLICY_DOCUMENT.read_text())
-        measurements = budgets.measure_repository()
 
-        self.assertEqual(17, len(measurements))
-        self.assertEqual([], budgets.check(loaded, measurements))
+        self.assertEqual([], budgets.check(loaded, budgets.measure_repository()))
 
 
 if __name__ == "__main__":

--- a/tests/test_notebook_output_budgets.py
+++ b/tests/test_notebook_output_budgets.py
@@ -1,0 +1,282 @@
+"""Contracts for the committed-output size budgets in CONTRIBUTING.md."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from notebook_test_support import REPO_ROOT
+
+
+BUDGETS_MODULE_PATH = REPO_ROOT / "scripts" / "check_notebook_output_budgets.py"
+SPEC = importlib.util.spec_from_file_location(
+    "check_notebook_output_budgets", BUDGETS_MODULE_PATH
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+budgets = importlib.util.module_from_spec(SPEC)
+# The module defines dataclasses, which resolve their annotations through
+# sys.modules while the class body is processed.
+sys.modules[SPEC.name] = budgets
+SPEC.loader.exec_module(budgets)
+
+KB = 1024
+POLICY_DOCUMENT = REPO_ROOT / "CONTRIBUTING.md"
+
+
+def policy_document(budget_rows: str, exception_rows: str) -> str:
+    """Build a minimal policy document with the two tables the check reads."""
+    return "\n".join(
+        [
+            "### Size budgets",
+            "",
+            "| Scope | Budget |",
+            "| --- | --- |",
+            budget_rows,
+            "",
+            "### Documented exceptions",
+            "",
+            "| Notebook | Scope | Granted ceiling | What the stored output is |",
+            "| --- | --- | --- | --- |",
+            exception_rows,
+            "",
+        ]
+    )
+
+
+DEFAULT_BUDGET_ROWS = "\n".join(
+    [
+        "| One code cell | 256 KB of stored output |",
+        "| One notebook | 1.0 MB of stored output |",
+        "| All notebooks | 10 MB of stored output |",
+    ]
+)
+
+
+def measurement(notebook: str, *cell_sizes: int) -> object:
+    return budgets.Measurement(
+        notebook=notebook,
+        stored_bytes=sum(cell_sizes),
+        cell_bytes=tuple(enumerate(cell_sizes)),
+    )
+
+
+def policy(**grants: int) -> object:
+    """Build the default budgets, with grants keyed as ``stem__scope``.
+
+    ``a__cell=448 * KB`` grants 448 KB to one code cell of ``a.ipynb``.
+    """
+    scopes = {"cell": budgets.CELL_SCOPE, "notebook": budgets.NOTEBOOK_SCOPE}
+    return budgets.Policy(
+        budgets={
+            budgets.CELL_SCOPE: 256 * KB,
+            budgets.NOTEBOOK_SCOPE: 1024 * KB,
+            budgets.COLLECTION_SCOPE: 10 * 1024 * KB,
+        },
+        grants={
+            (f"{stem}.ipynb", scopes[scope]): ceiling
+            for stem, scope, ceiling in (
+                (*name.rsplit("__", 1), ceiling) for name, ceiling in grants.items()
+            )
+        },
+    )
+
+
+class PolicySizeTests(unittest.TestCase):
+    def test_reads_kilobytes_and_fractional_megabytes(self) -> None:
+        self.assertEqual(256 * KB, budgets.parse_size("256 KB of stored output"))
+        self.assertEqual(1024 * KB, budgets.parse_size("1.0 MB"))
+        self.assertEqual(2400 * KB, budgets.parse_size("2400 KB"))
+
+    def test_rejects_a_size_without_a_unit_the_check_understands(self) -> None:
+        for text in ("256", "256 bytes", "a lot", "0.5 GB"):
+            with self.subTest(size=text):
+                with self.assertRaisesRegex(ValueError, "Not a policy size"):
+                    budgets.parse_size(text)
+
+
+class PolicyParsingTests(unittest.TestCase):
+    def test_reads_the_committed_budgets_and_exceptions(self) -> None:
+        loaded = budgets.load_policy(POLICY_DOCUMENT.read_text())
+
+        self.assertEqual(
+            {budgets.CELL_SCOPE, budgets.NOTEBOOK_SCOPE, budgets.COLLECTION_SCOPE},
+            set(loaded.budgets),
+        )
+        self.assertTrue(loaded.grants)
+        for (notebook, scope), ceiling in loaded.grants.items():
+            with self.subTest(notebook=notebook, scope=scope):
+                self.assertTrue((REPO_ROOT / notebook).is_file())
+                self.assertGreater(ceiling, loaded.budgets[scope])
+
+    def test_requires_every_budget_scope(self) -> None:
+        document = policy_document("| One notebook | 1.0 MB |", "")
+        with self.assertRaisesRegex(ValueError, "missing scopes"):
+            budgets.load_policy(document)
+
+    def test_rejects_an_exception_scope_that_is_not_a_budget_scope(self) -> None:
+        # Defect class: an exception row names a scope the check does not
+        # measure, so the row reads as a granted allowance and enforces nothing.
+        document = policy_document(
+            DEFAULT_BUDGET_ROWS,
+            "| `notebooks_py/2-QUBO_python.ipynb` | Two cells | 448 KB | plots |",
+        )
+        with self.assertRaisesRegex(ValueError, "not one of"):
+            budgets.load_policy(document)
+
+    def test_rejects_an_exception_to_the_collection_budget(self) -> None:
+        document = policy_document(
+            DEFAULT_BUDGET_ROWS,
+            "| `notebooks_py/2-QUBO_python.ipynb` | All notebooks | 20 MB | plots |",
+        )
+        with self.assertRaisesRegex(ValueError, "takes no exception"):
+            budgets.load_policy(document)
+
+    def test_rejects_two_rows_granting_the_same_scope(self) -> None:
+        document = policy_document(
+            DEFAULT_BUDGET_ROWS,
+            "\n".join(
+                [
+                    "| `notebooks_py/2-QUBO_python.ipynb` | One notebook | 2 MB | plots |",
+                    "| `notebooks_py/2-QUBO_python.ipynb` | One notebook | 3 MB | plots |",
+                ]
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "Duplicate exception row"):
+            budgets.load_policy(document)
+
+    def test_rejects_a_section_without_a_table(self) -> None:
+        document = "### Size budgets\n\nNo table here.\n\n### Documented exceptions\n"
+        with self.assertRaisesRegex(ValueError, "no table"):
+            budgets.load_policy(document)
+
+
+class MeasurementTests(unittest.TestCase):
+    def test_measures_stored_output_as_compact_utf8_json(self) -> None:
+        # Defect class: the measurement drifts from the definition the policy
+        # states, so the numbers in review stop matching the numbers in the doc.
+        self.assertEqual(2, budgets.cell_output_bytes({"outputs": []}))
+        self.assertEqual(2, budgets.cell_output_bytes({}))
+        # Compact separators: an indented serialization would be longer.
+        self.assertEqual(4, budgets.cell_output_bytes({"outputs": [{}]}))
+        # Non-ASCII text counts its UTF-8 length rather than an escape sequence.
+        self.assertEqual(
+            1,
+            budgets.cell_output_bytes({"outputs": [{"text": "é"}]})
+            - budgets.cell_output_bytes({"outputs": [{"text": "e"}]}),
+        )
+
+    def test_measures_code_cells_only(self) -> None:
+        notebook = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["# Title"], "outputs": [{"text": "x"}]},
+                {"cell_type": "code", "source": ["1"], "outputs": [{"text": "x"}]},
+                {"cell_type": "code", "source": ["2"]},
+            ]
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.ipynb"
+            path.write_text(json.dumps(notebook))
+            measured = budgets.measure_notebook(path)
+
+        self.assertEqual([1, 2], [index for index, _size in measured.cell_bytes])
+        self.assertEqual(2, measured.cell_bytes[1][1])
+        self.assertEqual(measured.cell_bytes[0][1] + 2, measured.stored_bytes)
+        self.assertEqual((1, measured.cell_bytes[0][1]), measured.largest_cell)
+
+
+class BudgetViolationTests(unittest.TestCase):
+    def test_accepts_a_notebook_inside_both_budgets(self) -> None:
+        self.assertEqual(
+            [],
+            budgets.check(policy(), [measurement("a.ipynb", 200 * KB, 100 * KB)]),
+        )
+
+    def test_flags_a_cell_over_the_cell_budget(self) -> None:
+        violations = budgets.check(
+            policy(), [measurement("a.ipynb", 100 * KB, 300 * KB)]
+        )
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("cell 1 stores 300.0 KB", violations[0])
+        self.assertIn("over the 256.0 KB budget", violations[0])
+
+    def test_flags_a_notebook_over_the_notebook_budget(self) -> None:
+        violations = budgets.check(
+            policy(), [measurement("a.ipynb", *([200 * KB] * 6))]
+        )
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("stores 1.17 MB", violations[0])
+        self.assertIn("over the 1.00 MB budget", violations[0])
+
+    def test_a_grant_bounds_the_scope_it_covers(self) -> None:
+        # Defect class: an exception is read as a waiver, so a granted notebook
+        # or cell can keep growing with nothing left to report it.
+        within = measurement("a.ipynb", 100 * KB, 400 * KB)
+        past = measurement("a.ipynb", 100 * KB, 500 * KB)
+
+        self.assertEqual([], budgets.check(policy(a__cell=448 * KB), [within]))
+        violations = budgets.check(policy(a__cell=448 * KB), [past])
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("over the 448.0 KB granted ceiling", violations[0])
+
+    def test_flags_a_grant_that_is_no_longer_needed(self) -> None:
+        # Defect class: a reduction lands and its exception row survives,
+        # leaving the table describing an allowance nothing uses.
+        violations = budgets.check(
+            policy(a__notebook=1248 * KB),
+            [measurement("a.ipynb", *([180 * KB] * 5))],
+        )
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("no longer needed", violations[0])
+        self.assertIn("900.0 KB now fits the 1.00 MB budget", violations[0])
+
+    def test_flags_a_grant_that_allows_less_than_the_budget(self) -> None:
+        violations = budgets.check(
+            policy(a__cell=100 * KB), [measurement("a.ipynb", 90 * KB)]
+        )
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("already allows", violations[0])
+
+    def test_flags_a_grant_for_a_notebook_that_does_not_exist(self) -> None:
+        violations = budgets.check(
+            policy(gone__notebook=2 * 1024 * KB), [measurement("a.ipynb", 90 * KB)]
+        )
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("does not exist", violations[0])
+
+    def test_flags_the_collection_total_and_takes_no_exception(self) -> None:
+        measurements = [
+            measurement(f"{index}.ipynb", *([180 * KB] * 5)) for index in range(12)
+        ]
+
+        violations = budgets.check(policy(), measurements)
+
+        self.assertEqual(1, len(violations))
+        self.assertIn("All notebooks: store 10.55 MB", violations[0])
+        self.assertIn("takes no exception", violations[0])
+
+
+class CommittedOutputBudgetTests(unittest.TestCase):
+    def test_committed_notebooks_are_within_the_documented_budgets(self) -> None:
+        # Defect class: a re-executed notebook commits a larger or duplicated
+        # figure, which no other check sees because the book build never runs
+        # a notebook and every source-level contract still holds.
+        loaded = budgets.load_policy(POLICY_DOCUMENT.read_text())
+        measurements = budgets.measure_repository()
+
+        self.assertEqual(17, len(measurements))
+        self.assertEqual([], budgets.check(loaded, measurements))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notebook_output_budgets.py
+++ b/tests/test_notebook_output_budgets.py
@@ -154,6 +154,24 @@ class PolicyParsingTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "no table"):
             budgets.load_policy(document)
 
+    def test_accepts_an_exception_table_with_no_rows(self) -> None:
+        # Defect class: the policy tells a reduction to delete the last stale
+        # exception row, and the check then rejects the state it asked for.
+        loaded = budgets.load_policy(policy_document(DEFAULT_BUDGET_ROWS, ""))
+
+        self.assertEqual({}, loaded.grants)
+        self.assertEqual(1024 * KB, loaded.budgets[budgets.NOTEBOOK_SCOPE])
+        self.assertEqual(
+            [],
+            budgets.check(loaded, [measurement("a.ipynb", 200 * KB, 100 * KB)]),
+        )
+
+    def test_still_requires_the_budget_rows(self) -> None:
+        document = policy_document("", "")
+
+        with self.assertRaisesRegex(ValueError, "has no rows"):
+            budgets.load_policy(document)
+
     def test_names_a_renamed_column_the_check_reads(self) -> None:
         # Defect class: an edit to the policy table surfaces as a traceback from
         # wherever a value was read, instead of naming the column to restore.
@@ -181,8 +199,14 @@ class MeasurementTests(unittest.TestCase):
         # states, so the numbers in review stop matching the numbers in the doc.
         self.assertEqual(2, budgets.cell_output_bytes({"outputs": []}))
         self.assertEqual(2, budgets.cell_output_bytes({}))
-        # Compact separators: an indented serialization would be longer.
-        self.assertEqual(4, budgets.cell_output_bytes({"outputs": [{}]}))
+        # Compact separators. An object with several fields is what distinguishes
+        # them: `[{"name":"stdout","text":"x"}]` is 30 bytes, where the default
+        # `", "` and `": "` would give 33. A single empty object cannot tell the
+        # two apart, so it is not a fixture for this.
+        self.assertEqual(
+            30,
+            budgets.cell_output_bytes({"outputs": [{"name": "stdout", "text": "x"}]}),
+        )
         # Non-ASCII text counts its UTF-8 length rather than an escape sequence.
         self.assertEqual(
             1,


### PR DESCRIPTION
## Summary

The output-size policy landed in #133 as prose with nothing behind it. This adds
the check, and closes the one gap the policy names as most likely to pass
unnoticed.

`scripts/check_notebook_output_budgets.py` measures stored output the way
`CONTRIBUTING.md` defines it — the compact-JSON UTF-8 length of each code cell's
`outputs` array — and reads both the budget table and the exception table out of
that file. The tables are therefore the enforced policy rather than a
description of one; there is no second copy of the numbers to drift.

Every exception now carries a **granted ceiling** instead of an open-ended
waiver. That is the substantive policy change here: a notebook already holding a
grant could previously absorb any amount of new output, which is exactly the
case the policy called out. Each ceiling is the size the grant was written
against plus roughly ten percent, rounded up to the next 32 KB, so an ordinary
re-render fits and a new or duplicated figure does not.

A grant that a later reduction makes unnecessary is reported as well, so the
table cannot outlive the exception it records. That matters for the reduction
work in #130 that follows this PR: shrinking `1-MathProg_python` back under
1.0 MB will fail the check until its row is deleted.

Current state, from the check's own report:

```
17 notebooks store 7.66 MB of output, against a 10.00 MB budget.
```

## Scope

This is the mechanical half of #130, sequenced first per the maintainer comment
on #131: the reduction work rewrites `1-MathProg_python` and `4-DWAVE_python`,
notebook JSON merges badly, and the size check is more useful in place before
new execution paths start producing figures.

**Merging this leaves #130 open.** The unmet criterion is "the largest notebooks
are reduced where this can be done without losing pedagogical information",
which needs a separate PR that re-executes notebooks. Nothing in this PR
re-executes a notebook or changes a single byte of committed output. The issue
closes when that reduction PR lands.

| #130 acceptance criterion | State |
| --- | --- |
| A documented output-retention and size policy exists | Satisfied by #133; this PR makes it executable and adds per-exception ceilings |
| The largest notebooks are reduced where possible | **Not addressed** — deferred to the reduction PR, see above |
| CI detects accidental large output growth while allowing reviewed exceptions | Satisfied: a CI step, plus the same contract under `make test-python` |
| The strict book build and notebook-output reproducibility tests continue to pass | Satisfied; no book input changed |

The investigation step "identify which rich outputs account for most of the
payload" is answered in the exception table, which now names what each grant
holds — including the finding that `1-MathProg_python` is over budget only
because one feasible-region figure is stored eight times.

## Enforcement is in two places on purpose

- `make check-notebook-output-budgets`, wired into CI as its own step, so a
  violation is legible in the log alongside the size report.
- `tests/test_notebook_output_budgets.py`, which calls the same module under
  `make test-python`, so deleting the CI step does not silently disable the
  guard. There is one implementation, with two entry points.

## Verification

Run in the repository `.venv` (Python 3.13.5) and, for the suite, in CI's locked
environment (`uv run --locked --group docs python`, Python 3.12):

- `make test-python` — 147 tests, OK, in both environments (122 before this PR,
  25 added).
- `make check-notebook-output-budgets` — exit 0, report above.
- `make test` and `make check-notebook-output-hygiene` — pass.
- The strict book build ran in CI on this head and passed: the Markdown edits
  match the `jupyter-book.yml` path filter, so its `build` job executed
  `jupyter book build --html --ci --strict`. `myst.yml`'s table of contents
  lists only `index.md`, `local-setup.md`, and the notebooks, none of which this
  PR touches; the relative-link contract over `README.md` and `CONTRIBUTING.md`
  runs in `make test-python` and passes.
- The repository documents no lint, format, or type-check command, so none was
  run.

### Mutation evidence

The deliverable is a guard, so each defect class was reproduced against a real
notebook and reverted. In every case the check exited non-zero and the new test
module went red:

| Mutation | Reported as |
| --- | --- |
| 300 KB into one cell of `6-QCi` | `cell 3 stores 300.1 KB … over the 256.0 KB budget` |
| 40 × 30 KB spread across `6-QCi`, no cell near budget | `stores 1.18 MB … over the 1.00 MB budget` |
| 100 KB onto the largest cell of `4-DWAVE_python` | `cell 25 stores 499.6 KB … over the 448.0 KB granted ceiling` |
| 300 KB spread across `1-MathProg_python` | `stores 1.40 MB … over the 1.22 MB granted ceiling` |
| image outputs cleared from `1-MathProg_python` | `the 'One notebook' exception is no longer needed — 15.3 KB now fits the 1.00 MB budget` |
| 3 MB into `7-CanonicalProblems` | notebook, cell, **and** `All notebooks: store 10.66 MB … over the 10.00 MB budget` |

For five of the six, the pre-existing 122 tests all stayed green — that is what
the guard uniquely adds. The sixth was also caught by
`test_canonical_problems_notebook`, which pins that one notebook's own output
shape; no existing check looks at output *size* anywhere.

Every guard added while addressing review was mutation-proved the same way.
Removing the column validation, the row-width validation, or the empty-cohort
refusal reddens exactly its own test; narrowing `NOTEBOOK_DIRS` to one directory
reddens the cohort-agreement test; restoring the default JSON separators reddens
the compactness assertion; and requiring a row in the exceptions table reddens
the empty-table test. The pre-existing 122 tests stay green under all six.

## Branch Hygiene

Branched from `origin/main` at `ae4d13d`. Not stacked, no prerequisite PR. No
other PR was open when this branch was created, so no file overlap to record.

Refs #130
